### PR TITLE
Fix iheart.pl bugs, add retry/skip-existing/custom-name, move stations to stations.txt

### DIFF
--- a/iheart-radio/.gitignore
+++ b/iheart-radio/.gitignore
@@ -1,0 +1,2 @@
+# Ignore generated playlists, images, and completion markers
+playlists/

--- a/iheart-radio/README.md
+++ b/iheart-radio/README.md
@@ -25,11 +25,21 @@ Ensure you have the StreamFinder::IHeartRadio Perl module installed to utilize t
 
 Run the script with appropriate arguments or configuration to fetch station URLs, generate M3U playlists, and gather associated station information.
 
+iheart.com intermittently serves a page without the embedded stream data it needs, so a station may fail even though it's valid. Each station is retried automatically up to 3 times before being skipped; override this with `--retries=N` (or `-r N`). Pass `--skip-existing` (or `-s`) to also let you re-run the script multiple times without redoing stations that already succeeded in a previous run:
+
+```
+perl iheart.pl -s -r 5
+```
+
+Completed stations are tracked as marker files under `playlists/.completed/`; delete that directory (or an individual marker) to force a station to be re-fetched.
+
 ### Configuration
 
-Ensure you have the necessary credentials or configurations set up within the script or provided as arguments for the script to function correctly.
+Station URLs live in [`stations.txt`](./stations.txt), one iheart.com URL per line (blank lines and `#`-prefixed comments are ignored) — edit that file to add or remove stations instead of editing `iheart.pl`. By default the script reads `stations.txt` next to itself; point it at a different file with `--stations=FILE` (or `-f FILE`).
+
+By default the playlist/image filenames are derived from the station's title as fetched from iheart.com. To pin a specific filename instead, append it after a comma: `https://www.iheart.com/live/some-station/,My Station Name`.
 
 ### License
 
-This project is licensed under the **GNU General Public License v3**. For more information, see [LICENSE](../LICENSE).
+This project is licensed under the **GNU General Public License v3.0**. For more information, see [LICENSE](../LICENSE).
 

--- a/iheart-radio/iheart.pl
+++ b/iheart-radio/iheart.pl
@@ -4,6 +4,8 @@
 # along with associated station information, including titles,
 # stream URLs, and optional station images. Utilizes StreamFinder::IHeartRadio
 # Perl module for data retrieval and saves data in a 'playlists' directory.
+# Station URLs are read from stations.txt (see --stations) so the list can
+# be edited without touching this script.
 # Requires LWP::Simple and File::Path modules for downloading images
 # and managing directories.
 
@@ -17,48 +19,93 @@
 
 use strict;
 use warnings;
+use FindBin qw($RealBin);
+use Getopt::Long;
 use StreamFinder::IHeartRadio;  # Fetch iHeartRadio station details
 use LWP::Simple;               # For downloading station images
 use File::Path qw(make_path);   # For managing directories
 
+# iheart.com intermittently serves a page without the embedded stream data,
+# so a station lookup that fails once may succeed on a retry.
+use constant RETRY_DELAY_SECONDS => 3;
+
+# With --skip-existing, stations already completed in a prior run are left
+# untouched instead of being re-fetched, so the script can be re-run as many
+# times as needed to pick up the stations iheart.com failed on previously.
+# --retries overrides how many attempts each station gets (default: 3).
+# --stations points at the station list file (default: stations.txt next to this script).
+my $skipExisting = 0;
+my $maxAttempts = 3;
+my $stationsFile = "$RealBin/stations.txt";
+GetOptions(
+    'skip-existing|s' => \$skipExisting,
+    'retries|r=i'     => \$maxAttempts,
+    'stations|f=s'    => \$stationsFile,
+) or die "Usage: $0 [--skip-existing|-s] [--retries|-r N] [--stations|-f FILE]\n";
+die "--retries must be a positive integer\n" unless $maxAttempts > 0;
+
 my $playlistDir = "./playlists";  # Directory to store playlists
 make_path($playlistDir);
 
-my @playlistData = (
-    ["https://www.iheart.com/live/kssn-96-105/", ""],
-    ["https://www.iheart.com/live/kix-104-3454/", ""],
-    ["https://www.iheart.com/live/hot-1019-3442/", ""],
-    ["https://www.iheart.com/live/1051-the-wolf-little-rock-93/", ""],
-    ["https://www.iheart.com/live/magic-1079-3446/", ""],
-    ["https://www.iheart.com/live/k-mag-991-109/", ""],
-    ["https://www.iheart.com/live/933-the-eagle-3450/", ""],
-    ["https://www.iheart.com/live/1003-the-edge-89/", ""],
-    ["https://www.iheart.com/live/hot-949-101/", ""],
-    ["https://www.iheart.com/live/b98-fort-smith-117/", ""],
-    ["https://www.iheart.com/live/big-dog-959-113/", ""],
-    ["https://www.iheart.com/live/news-talk-1320-kwhn-4250/", ""],
+my $completedDir = "$playlistDir/.completed";  # Marker files recording finished stations
+make_path($completedDir);
 
-);   # Replace with your actual station URLs and empty playlist filenames
+open my $stations_fh, '<', $stationsFile or die "Cannot open stations file $stationsFile: $!\n";
+my @stations;
+while (my $line = <$stations_fh>) {
+    $line =~ s/^\s+|\s+$//g;  # Trim whitespace
+    next if $line eq '' || $line =~ /^#/;  # Skip blank lines and comments
 
-foreach my $stationInfo (@playlistData) {
-    my ($stationURL, $playlistFilename) = @$stationInfo;  # Destructure array reference
+    # Optional "URL,custom-name" — custom-name overrides the derived-from-title
+    # filename below; leave it blank (or omit the comma) to keep that behavior.
+    my ($url, $customName) = split /\s*,\s*/, $line, 2;
+    push @stations, [$url, $customName];
+}
+close $stations_fh;
 
-    # Extract station ID from URL using regex
-    my ($stationID) = $stationURL =~ m|/live/([^/]+)/|;
+die "No station URLs found in $stationsFile\n" unless @stations;
 
-    my $station = StreamFinder::IHeartRadio->new($stationID, -keep => ['secure_shoutcast', 'secure', 'any'], -skip => 'rtmp');
+foreach my $stationEntry (@stations) {
+    my ($stationURL, $customName) = @$stationEntry;
+    # Stable per-station identifier (last URL path segment) used only for the
+    # completion marker below; the full URL is still what's passed to the module.
+    (my $urlNoSlash = $stationURL) =~ s{/+$}{};
+    my ($stationID) = $urlNoSlash =~ m{([^/]+)$};
+    my $markerFile = "$completedDir/$stationID.done";
+
+    if ($skipExisting && -e $markerFile) {
+        print "Skipping $stationURL (already completed in a previous run)\n";
+        next;
+    }
+
+    # StreamFinder::IHeartRadio extracts the station ID from a full URL itself,
+    # so pass it straight through rather than re-parsing it here.
+    my $station;
+    for my $attempt (1 .. $maxAttempts) {
+        $station = StreamFinder::IHeartRadio->new($stationURL, -keep => ['secure_shoutcast', 'secure', 'any'], -skip => 'rtmp');
+        last if $station;
+
+        if ($attempt < $maxAttempts) {
+            warn "Attempt $attempt/$maxAttempts failed for $stationURL, retrying in @{[RETRY_DELAY_SECONDS]}s...\n";
+            sleep RETRY_DELAY_SECONDS;
+        }
+    }
 
     unless ($station) {
-        warn "Invalid URL or no streams found for $playlistFilename\n";
+        warn "Invalid URL or no streams found for $stationURL after $maxAttempts attempts\n";
         next;
     }
 
     my $stationTitle = $station->getTitle();  # Fetch station title/name
 
-    # Remove unwanted characters from the station name to use as playlist and image filenames
-    my $safeFilename = $stationTitle =~ s/[^\w.-]+/_/gr;
+    # A custom name from stations.txt overrides the derived-from-title filename;
+    # otherwise fall back to the station's title, same as before.
+    my $filenameBase = (defined $customName && $customName ne '') ? $customName : $stationTitle;
 
-    $playlistFilename = "$playlistDir/$safeFilename.m3u";  # Set playlist filename using station name within the directory
+    # Remove unwanted characters from the name to use as playlist and image filenames
+    my $safeFilename = $filenameBase =~ s/[^\w.-]+/_/gr;
+
+    my $playlistFilename = "$playlistDir/$safeFilename.m3u";  # Set playlist filename using station name within the directory
     my $imageFilename = "$playlistDir/$safeFilename.png";  # Set image filename using station name within the directory
 
     my $firstStream = $station->getURL();
@@ -89,5 +136,8 @@ foreach my $stationInfo (@playlistData) {
     close $playlist_fh;
 
     print "Playlist created for $playlistFilename\n";
+
+    open my $marker_fh, '>', $markerFile or warn "Cannot create marker file $markerFile: $!\n";
+    close $marker_fh if $marker_fh;
 }
 

--- a/iheart-radio/stations.txt
+++ b/iheart-radio/stations.txt
@@ -1,0 +1,21 @@
+# iheart.pl station list
+#
+# One iheart.com station URL per line. Blank lines and lines starting
+# with '#' are ignored. Playlist and image filenames are derived
+# automatically from each station's title, so nothing else is needed
+# here. To pin the output filename instead, append ",custom-name":
+#
+#   https://www.iheart.com/live/some-station/,My Station Name
+
+https://www.iheart.com/live/alice-1077-5416/
+https://www.iheart.com/live/kssn-96-country-105/
+https://www.iheart.com/live/hot-1019-3442/
+https://www.iheart.com/live/1051-the-wolf-little-rock-93/
+https://www.iheart.com/live/magic-1079-3446/
+https://www.iheart.com/live/k-mag-991-109/
+https://www.iheart.com/live/933-the-eagle-3450/
+https://www.iheart.com/live/1003-the-edge-89/
+https://www.iheart.com/live/hot-949-101/
+https://www.iheart.com/live/b98-117/
+https://www.iheart.com/live/big-dog-959-113/
+https://www.iheart.com/live/news-talk-1320-kwhn-4250/


### PR DESCRIPTION
## Summary
- Fix a station-ID regex that silently dropped stations without a trailing slash, and fix a warning that printed an empty filename instead of the failing URL.
- Retry a station lookup (default 3x, override with `--retries`/`-r`) since iheart.com intermittently serves a page without the embedded stream data needed to resolve a station.
- Add `--skip-existing`/`-s` to skip stations already completed in a prior run (tracked via marker files under `playlists/.completed/`), so the script can be safely re-run to pick up transient failures.
- Move the station list out of `iheart.pl` into `stations.txt` (one URL per line, optional `,custom-name` to pin the output filename) so stations can be added/removed without editing the script; `--stations`/`-f` points at an alternate file.
- Add `iheart-radio/.gitignore` for the generated `playlists/` directory, matching the pattern already used by `somafm` and `mpd-notifier`.

## Test plan
- [x] `perl -c iheart.pl` syntax check
- [x] Ran end-to-end against live iheart.com with the real `StreamFinder::IHeartRadio` module (v2.62) installed locally
- [x] Verified `--skip-existing` skips previously-completed stations on a second run without re-fetching them
- [x] Verified `--retries=N` changes the attempt count (0 retry messages with `-r 1`)
- [x] Verified `stations.txt` custom-name override produces the pinned filename, while entries without one still derive the name from the station title