### PR TITLE
Fix current-volume parsing bug in volume/mpc scripts (#27)

### DIFF
--- a/volume/mpc/mpdvoldown.py
+++ b/volume/mpc/mpdvoldown.py
@@ -58,7 +58,7 @@ def get_current_volume():
     """
     try:
         output = subprocess.check_output(["mpc", "volume"]).decode().strip()
-        current_volume = int(output.split()[0].strip("%"))
+        current_volume = int(output.split()[1].strip("%"))
         return current_volume
     except Exception as e:
         print(f"Error: {e}")

--- a/volume/mpc/mpdvolup.py
+++ b/volume/mpc/mpdvolup.py
@@ -64,7 +64,7 @@ def main():
     if len(sys.argv) == 1:
         try:
             output = subprocess.check_output(["mpc", "volume"]).decode().strip()
-            current_volume = int(output.split()[0].strip("%"))
+            current_volume = int(output.split()[1].strip("%"))
             print(f"usage: {sys.argv[0]} [-h] [amount]\nCurrent volume: {current_volume}%")
         except Exception as e:
             print(f"Error: {e}")
@@ -79,7 +79,7 @@ def main():
     # Retrieve current volume
     try:
         output = subprocess.check_output(["mpc", "volume"]).decode().strip()
-        current_volume = int(output.split()[0].strip("%"))
+        current_volume = int(output.split()[1].strip("%"))
     except Exception as e:
         print(f"Error: {e}")
         sys.exit(1)

--- a/volume/mpc/volume.py
+++ b/volume/mpc/volume.py
@@ -71,7 +71,7 @@ def main():
     # If no arguments provided, show usage and current volume
     if not args.direction:
         try:
-            current_volume = int(subprocess.getoutput("mpc volume").split()[0])
+            current_volume = int(subprocess.getoutput("mpc volume").split()[1].strip("%"))
             print(f"usage: {sys.argv[0]} [-h] {{up,down}} [amount]\nCurrent volume: {current_volume}%")
         except Exception as e:
             print(f"Error: {e}")
@@ -81,7 +81,7 @@ def main():
     try:
         if args.direction == 'up':
             if toggle_max_volume:
-                current_volume = int(subprocess.getoutput("mpc volume").split()[0])
+                current_volume = int(subprocess.getoutput("mpc volume").split()[1].strip("%"))
                 new_volume = min(current_volume + args.amount, max_volume)
                 subprocess.run(f"mpc volume {new_volume}", shell=True)
                 print(f"Volume increased by {new_volume - current_volume} units.")


### PR DESCRIPTION
Fixes #27

## Summary
Closes the actual functionality gap behind #27. The no-args "show current volume" feature added in #28 never worked: `mpc volume` prints `volume: NN%`, but the code read `.split()[0]` (the literal string `volume:`) instead of `.split()[1]` (the value), so every no-args invocation of `volume.py`, `mpdvolup.py`, and `mpdvoldown.py` silently failed with `Error: invalid literal for int() with base 10: 'volume:'` instead of printing the current volume.

## Test plan
- [x] Installed real `mpc`/`mpd` and ran a local mpd instance with a software mixer to get genuine `mpc volume` output
- [x] Confirmed the bug reproduces exactly as described against the live binary before the fix
- [x] Verified `volume.py`, `mpdvolup.py`, and `mpdvoldown.py` all now correctly print/adjust the current volume with no args and with an amount argument