### PR TITLE
Add issue templates to route non-bug reports to Discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,54 @@
+name: Bug Report
+description: Report a problem with one of the mpd-scripts scripts
+labels: ["bug"]
+body:
+  - type: dropdown
+    id: script
+    attributes:
+      label: Which script?
+      options:
+        - lastfm-love (loved.py / unloved.py)
+        - mpd-notifier
+        - tunein-radio (tunein.pl)
+        - iheart-radio (iheart.pl)
+        - volume (mpc)
+        - volume (python-mpd)
+        - mpd-queue-shuffle
+        - somafm
+        - mpd-find-dup
+        - mpd_rewind_daemon
+        - setup-path.sh
+        - Other / not sure
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Relevant tool/module version
+      description: Whatever applies, e.g. `mpc --version`, `perl -v`, `python3 --version`, or a Perl/Python module version.
+      placeholder: "mpc 0.34"
+    validations:
+      required: false
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Exact command you ran, and any relevant config (redact hostnames, passwords, API keys, etc.).
+      placeholder: |
+        ./volume.py up 5
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Log output / traceback
+      description: Paste the full terminal output. This will be formatted as code automatically.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions, feature requests, and general discussion
+    url: https://github.com/bonelifer/mpd-scripts/discussions
+    about: For anything that isn't a bug report, please use Discussions instead.


### PR DESCRIPTION
## Summary
Applies the same issue-template setup already used in other repos (e.g. `BlueSky-Suite`) here:
- `.github/ISSUE_TEMPLATE/bug_report.yml`: a structured bug-report form covering the scripts in this repo (lastfm-love, mpd-notifier, tunein-radio, iheart-radio, both volume variants, mpd-queue-shuffle, somafm, mpd-find-dup, mpd_rewind_daemon, setup-path.sh), labeled `bug`.
- `.github/ISSUE_TEMPLATE/config.yml`: disables blank issues and points everything else (questions, feature requests, discussion) at [Discussions](https://github.com/bonelifer/mpd-scripts/discussions), which is already enabled on this repo.

## Test plan
- [x] Validated both YAML files parse correctly