### PR TITLE
Bring tunein.pl to parity with iheart.pl

### DIFF
--- a/tunein-radio/.gitignore
+++ b/tunein-radio/.gitignore
@@ -1,0 +1,2 @@
+# Ignore generated playlists, images, and completion markers
+playlists/

--- a/tunein-radio/README.md
+++ b/tunein-radio/README.md
@@ -25,11 +25,21 @@ Ensure you have the StreamFinder::Tunein Perl module installed to utilize this s
 
 Run the script with appropriate arguments or configuration to fetch station URLs, generate M3U playlists, and gather associated station information.
 
+Each station is retried automatically up to 3 times before being skipped; override this with `--retries=N` (or `-r N`). Pass `--skip-existing` (or `-s`) to re-run the script multiple times without redoing stations that already succeeded in a previous run:
+
+```
+perl tunein.pl -s -r 5
+```
+
+Completed stations are tracked as marker files under `playlists/.completed/`; delete that directory (or an individual marker) to force a station to be re-fetched.
+
 ### Configuration
 
-Ensure you have the necessary credentials or configurations set up within the script or provided as arguments for the script to function correctly.
+Station URLs live in [`stations.txt`](./stations.txt), one tunein.com URL per line (blank lines and `#`-prefixed comments are ignored) — edit that file to add or remove stations instead of editing `tunein.pl`. By default the script reads `stations.txt` next to itself; point it at a different file with `--stations=FILE` (or `-f FILE`).
+
+By default the playlist/image filenames are derived from the station's title as fetched from tunein.com. To pin a specific filename instead, append it after a comma: `https://tunein.com/radio/some-station-s12345/,My Station Name`.
 
 ### License
 
-This project is licensed under the **GNU General Public License v3**. For more information, see [LICENSE](../LICENSE).
+This project is licensed under the **GNU General Public License v3.0**. For more information, see [LICENSE](../LICENSE).
 

--- a/tunein-radio/stations.txt
+++ b/tunein-radio/stations.txt
@@ -1,0 +1,29 @@
+# tunein.pl station list
+#
+# One tunein.com station URL per line. Blank lines and lines starting
+# with '#' are ignored. Playlist and image filenames are derived
+# automatically from each station's title. To pin the output filename
+# instead, append ",custom-name":
+#
+#   https://tunein.com/radio/some-station-s12345/,My Station Name
+
+https://tunein.com/radio/KUAR-891-s35843/
+https://tunein.com/radio/KUAF-913-s35839/
+https://tunein.com/radio/KUAF-2-913-s97277/
+https://tunein.com/radio/KUAF-3-913-s97278/
+https://tunein.com/radio/KUHS-LP-Hot-Springs-1025-s252058/
+https://tunein.com/radio/Power-92-Jams-923-s33199/
+https://tunein.com/radio/KVRE-929-s26151/
+https://tunein.com/radio/The-Point-941-s33572/
+https://tunein.com/radio/KSSN-96-957-s35494/
+https://tunein.com/radio/US-97-975-s34897/
+https://tunein.com/radio/B985-s35941/
+https://tunein.com/radio/1003-The-Edge-s34781/
+https://tunein.com/radio/Rock-1015-s33220/
+https://tunein.com/radio/KJDS-1019-s26744/
+https://tunein.com/radio/1029-KARN-News-Radio-s36053/
+https://tunein.com/radio/1037-The-Buzz-s31328/
+https://tunein.com/radio/1051-The-Wolf-Little-Rock-s34059/
+https://tunein.com/radio/KLAZ-1059-s33665/
+https://tunein.com/radio/Alice-1077-s33655/
+https://tunein.com/radio/CER2-Radio-690-s32531/

--- a/tunein-radio/tunein.pl
+++ b/tunein-radio/tunein.pl
@@ -3,7 +3,9 @@
 # Fetches TuneIn radio station URLs and generates M3U playlists
 # with associated station information including titles, stream URLs,
 # and optional station images. Utilizes StreamFinder::Tunein Perl
-# module for data retrieval and saves data in an 'archive' directory.
+# module for data retrieval and saves data in a 'playlists' directory.
+# Station URLs are read from stations.txt (see --stations) so the list
+# can be edited without touching this script.
 # Requires LWP::Simple module for image downloading.
 
 # To install required Perl modules:
@@ -16,53 +18,94 @@
 
 use strict;
 use warnings;
+use FindBin qw($RealBin);
+use Getopt::Long;
 use StreamFinder::Tunein;  # Fetch TuneIn station details
 use LWP::Simple;          # For downloading station images
 
-# Array of station URLs and their corresponding playlist names
-my @stations = (
-    { url => 'https://tunein.com/radio/KUAR-891-s35843/', playlist_name => '' },
-    { url => 'https://tunein.com/radio/KUAF-913-s35839/', playlist_name => '' },
-    { url => 'https://tunein.com/radio/KUAF-2-913-s97277/', playlist_name => '' },
-    { url => 'https://tunein.com/radio/KUAF-3-913-s97278/', playlist_name => '' },
-    { url => 'https://tunein.com/radio/KUHS-LP-Hot-Springs-1025-s252058/', playlist_name => '' },
-    { url => 'https://tunein.com/radio/Power-92-Jams-923-s33199/', playlist_name => '' },
-    { url => 'https://tunein.com/radio/KVRE-929-s26151/', playlist_name => '' },
-    { url => 'https://tunein.com/radio/The-Point-941-s33572/', playlist_name => '' },
-    { url => 'https://tunein.com/radio/KSSN-96-957-s35494/', playlist_name => '' },
-    { url => 'https://tunein.com/radio/US-97-975-s34897/', playlist_name => '' },
-    { url => 'https://tunein.com/radio/B985-s35941/', playlist_name => '' },
-    { url => 'https://tunein.com/radio/1003-The-Edge-s34781/', playlist_name => '' },
-    { url => 'https://tunein.com/radio/Rock-1015-s33220/', playlist_name => '' },
-    { url => 'https://tunein.com/radio/KJDS-1019-s26744/', playlist_name => '' },
-    { url => 'https://tunein.com/radio/1029-KARN-News-Radio-s36053/', playlist_name => '' },
-    { url => 'https://tunein.com/radio/1037-The-Buzz-s31328/', playlist_name => '' },
-    { url => 'https://tunein.com/radio/1051-The-Wolf-Little-Rock-s34059/', playlist_name => '' },
-    { url => 'https://tunein.com/radio/KLAZ-1059-s33665/', playlist_name => '' },
-    { url => 'https://tunein.com/radio/Alice-1077-s33655/', playlist_name => '' },
-    { url => 'https://tunein.com/radio/CER2-Radio-690-s32531/', playlist_name => '' },
-    # Add more stations as needed
-);
+# tunein.com can intermittently fail to resolve a valid station, so a
+# lookup that fails once may succeed on a retry.
+use constant RETRY_DELAY_SECONDS => 3;
 
-# Create archive directory if it doesn't exist
-my $archive_dir = 'archive';
-unless (-e $archive_dir && -d $archive_dir) {
-    mkdir $archive_dir or die "Unable to create directory: $!";
+# With --skip-existing, stations already completed in a prior run are left
+# untouched instead of being re-fetched, so the script can be re-run as many
+# times as needed to pick up any stations that failed previously.
+# --retries overrides how many attempts each station gets (default: 3).
+# --stations points at the station list file (default: stations.txt next to this script).
+my $skipExisting = 0;
+my $maxAttempts = 3;
+my $stationsFile = "$RealBin/stations.txt";
+GetOptions(
+    'skip-existing|s' => \$skipExisting,
+    'retries|r=i'     => \$maxAttempts,
+    'stations|f=s'    => \$stationsFile,
+) or die "Usage: $0 [--skip-existing|-s] [--retries|-r N] [--stations|-f FILE]\n";
+die "--retries must be a positive integer\n" unless $maxAttempts > 0;
+
+# Create playlists directory if it doesn't exist
+my $playlistDir = 'playlists';
+unless (-e $playlistDir && -d $playlistDir) {
+    mkdir $playlistDir or die "Unable to create directory: $!";
 }
 
-# Iterate through each station and fetch station images and generate M3U playlists
-foreach my $station (@stations) {
-    my $station_obj = StreamFinder::Tunein->new($station->{url});
+my $completedDir = "$playlistDir/.completed";  # Marker files recording finished stations
+unless (-e $completedDir && -d $completedDir) {
+    mkdir $completedDir or die "Unable to create directory: $!";
+}
 
-    next unless ($station_obj);  # Skip invalid URLs or stations without streams
+open my $stations_fh, '<', $stationsFile or die "Cannot open stations file $stationsFile: $!\n";
+my @stations;
+while (my $line = <$stations_fh>) {
+    $line =~ s/^\s+|\s+$//g;  # Trim whitespace
+    next if $line eq '' || $line =~ /^#/;  # Skip blank lines and comments
+
+    # Optional "URL,custom-name" — custom-name overrides the derived-from-title
+    # filename below; leave it blank (or omit the comma) to keep that behavior.
+    my ($url, $customName) = split /\s*,\s*/, $line, 2;
+    push @stations, [$url, $customName];
+}
+close $stations_fh;
+
+die "No station URLs found in $stationsFile\n" unless @stations;
+
+# Iterate through each station and fetch station images and generate M3U playlists
+foreach my $stationEntry (@stations) {
+    my ($stationURL, $customName) = @$stationEntry;
+
+    # Stable per-station identifier (last URL path segment) used only for the
+    # completion marker below; the full URL is still what's passed to the module.
+    (my $urlNoSlash = $stationURL) =~ s{/+$}{};
+    my ($stationID) = $urlNoSlash =~ m{([^/]+)$};
+    my $markerFile = "$completedDir/$stationID.done";
+
+    if ($skipExisting && -e $markerFile) {
+        print "Skipping $stationURL (already completed in a previous run)\n";
+        next;
+    }
+
+    my $station_obj;
+    for my $attempt (1 .. $maxAttempts) {
+        $station_obj = StreamFinder::Tunein->new($stationURL);
+        last if $station_obj;
+
+        if ($attempt < $maxAttempts) {
+            warn "Attempt $attempt/$maxAttempts failed for $stationURL, retrying in @{[RETRY_DELAY_SECONDS]}s...\n";
+            sleep RETRY_DELAY_SECONDS;
+        }
+    }
+
+    unless ($station_obj) {
+        warn "Invalid URL or no streams found for $stationURL after $maxAttempts attempts\n";
+        next;
+    }
 
     # Fetch station details
-    my $playlist_name = $station->{playlist_name} || $station_obj->getTitle() || 'Unknown Playlist';
+    my $playlist_name = (defined $customName && $customName ne '') ? $customName : ($station_obj->getTitle() || 'Unknown Playlist');
     my $station_image_url = $station_obj->getImageURL();
     my $stream_urls = $station_obj->get();
 
     # Write station information to the station's M3U playlist file
-    open(my $station_playlist_fh, '>', "$archive_dir/$playlist_name.m3u") or die "Cannot open station playlist file: $!";
+    open(my $station_playlist_fh, '>', "$playlistDir/$playlist_name.m3u") or die "Cannot open station playlist file: $!";
 
     # Write station information to the extended M3U playlist
     print $station_playlist_fh "#EXTINF:-1, $playlist_name\n";
@@ -87,12 +130,16 @@ foreach my $station (@stations) {
             # Determine the image extension
             my ($image_ext) = $station_image_url =~ m/\.([^.]+)$/;
 
-            # Save station image to the archive directory
-            open(my $image_fh, '>', "$archive_dir/$playlist_name.$image_ext") or die "Unable to create image file: $!";
+            # Save station image to the playlists directory
+            open(my $image_fh, '>', "$playlistDir/$playlist_name.$image_ext") or die "Unable to create image file: $!";
             binmode $image_fh;
             print $image_fh $image_data;
             close $image_fh;
         }
     }
-}
 
+    open my $marker_fh, '>', $markerFile or warn "Cannot create marker file $markerFile: $!\n";
+    close $marker_fh if $marker_fh;
+
+    print "Playlist created for $playlistDir/$playlist_name.m3u\n";
+}


### PR DESCRIPTION
## Summary
- Rename the output directory from `archive` to `playlists` (matching `iheart-radio`), with a `.gitignore` for it.
- Add automatic retry (default 3x, `--retries`/`-r` to override) and `--skip-existing`/`-s` to skip stations already completed in a prior run (tracked via marker files under `playlists/.completed/`), same behavior as `iheart.pl`.
- Move the station list out of `tunein.pl` into `stations.txt` (one URL per line, optional `,custom-name` to pin the output filename — the existing per-station custom `playlist_name` feature is preserved, just moved out of the script), with `--stations`/`-f` to point at an alternate file.

## Test plan
- [x] `perl -c tunein.pl` syntax check
- [x] Ran end-to-end against live tunein.com with `StreamFinder::Tunein` installed locally — all 20 stations succeeded
- [x] Verified `--skip-existing` skips all previously-completed stations on a second run
- [x] Verified the `stations.txt` custom-name override produces the pinned filename