### PR TITLE
Rename somafm channels dir to playlists, add channel icon downloading

### DIFF
--- a/somafm/.gitignore
+++ b/somafm/.gitignore
@@ -1,3 +1,4 @@
-*.m3u
+playlists/
+__pycache__/
 *.md.backup
 *.backup

--- a/somafm/README.md
+++ b/somafm/README.md
@@ -1,6 +1,6 @@
 # SomaFM Playlist Fetcher
 
-This Python script fetches the playlist URLs of SomaFM channels with the highest quality in MP3 format and creates separate playlists for each channel in extended M3U format with the channel name included.
+This Python script fetches the playlist URLs of SomaFM channels with the highest quality in MP3 format and creates separate playlists for each channel in extended M3U format with the channel name included, along with each channel's icon image.
 
 ## Dependencies
 
@@ -23,13 +23,19 @@ This Python script fetches the playlist URLs of SomaFM channels with the highest
    python soma_fm_playlist_fetcher.py
    ```
 
-5. The script will create a folder named `channels` in the current directory and save individual M3U playlists for each SomaFM channel in that folder.
+   Each channel's icon is downloaded at 120px by default; pass `--size` to choose 256px or 512px instead:
+
+   ```
+   python soma_fm_playlist_fetcher.py --size 512
+   ```
+
+5. The script will create a folder named `playlists` in the current directory and save individual M3U playlists and icon images for each SomaFM channel in that folder.
 
 ## File Structure
 
 - `soma_fm_playlist_fetcher.py`: The Python script to fetch and create SomaFM playlists.
 - `README.md`: This README file providing instructions and information about the script.
-- `channels/`: Folder containing the generated M3U playlist files for each SomaFM channel.
+- `playlists/`: Folder containing the generated M3U playlist files and channel icon images for each SomaFM channel.
 
 ***
 #### License: [GPLv3](../LICENSE)

--- a/somafm/README.md
+++ b/somafm/README.md
@@ -23,10 +23,10 @@ This Python script fetches the playlist URLs of SomaFM channels with the highest
    python soma_fm_playlist_fetcher.py
    ```
 
-   Each channel's icon is downloaded at 120px by default; pass `--size` to choose 256px or 512px instead:
+   Each channel's icon is downloaded at 120px by default; pass `--size` (or `-s`) to choose 256px or 512px instead:
 
    ```
-   python soma_fm_playlist_fetcher.py --size 512
+   python soma_fm_playlist_fetcher.py -s 512
    ```
 
 5. The script will create a folder named `playlists` in the current directory and save individual M3U playlists and icon images for each SomaFM channel in that folder.

--- a/somafm/soma_fm_playlist_fetcher.py
+++ b/somafm/soma_fm_playlist_fetcher.py
@@ -130,7 +130,7 @@ def create_playlist_file(channel_name, channel_data, folder, icon_size):
 
 def main():
     parser = argparse.ArgumentParser(description='Fetch SomaFM channel playlists and icons.')
-    parser.add_argument('--size', type=int, choices=sorted(ICON_SIZES), default=120,
+    parser.add_argument('-s', '--size', type=int, choices=sorted(ICON_SIZES), default=120,
                          help='Channel icon size in pixels to download (default: 120)')
     args = parser.parse_args()
 

--- a/somafm/soma_fm_playlist_fetcher.py
+++ b/somafm/soma_fm_playlist_fetcher.py
@@ -3,15 +3,24 @@
 """
 Homelab SomaFM Playlist Fetcher
 
-This script fetches the playlist URLs of SomaFM channels with the highest quality in MP3 format and creates separate playlists for each channel in extended M3U format with the channel name.
+This script fetches the playlist URLs of SomaFM channels with the highest quality in MP3 format and creates separate playlists for each channel in extended M3U format with the channel name, along with each channel's icon image.
 
 Dependencies:
     - requests: HTTP library for Python (https://requests.readthedocs.io)
 """
 
+import argparse
 import os
 import requests
 from requests.exceptions import HTTPError
+
+# SomaFM's channels.json exposes each channel's icon at three sizes, keyed
+# by these JSON field names.
+ICON_SIZES = {
+    120: 'image',
+    256: 'largeimage',
+    512: 'xlimage',
+}
 
 
 def get_channels(url):
@@ -32,19 +41,21 @@ def get_channels(url):
         print(f'HTTP error occurred:\n {http_err}')
     except Exception as err:
         print(f'Other error occurred: {err}')
-    
+
     return response
 
 
 def get_playlists(response):
     """
-    Extracts the playlist URLs with the highest quality in MP3 format from the response.
+    Extracts the playlist URLs with the highest quality in MP3 format, and each
+    channel's icon URL, from the response.
 
     Args:
         response (requests.Response): The response object containing the channel list.
 
     Returns:
-        dict: A dictionary containing channel names as keys and playlist URLs as values.
+        dict: A dictionary containing channel names as keys, and a dict of
+        'urls' (playlist URLs) and 'icon_urls' (by size) as values.
     """
     playlists = {}  # Store channel playlists
     for channel in response.json()['channels']:
@@ -52,36 +63,89 @@ def get_playlists(response):
         for playlist in channel['playlists']:
             if playlist['quality'] == 'highest' and playlist['format'] == 'mp3':
                 if channel_name not in playlists:
-                    playlists[channel_name] = []
-                playlists[channel_name].append(playlist['url'])
+                    playlists[channel_name] = {'urls': [], 'icon_urls': {}}
+                playlists[channel_name]['urls'].append(playlist['url'])
+
+        for size, field in ICON_SIZES.items():
+            icon_url = channel.get(field)
+            if icon_url:
+                playlists[channel_name]['icon_urls'][size] = icon_url
 
     return playlists
 
 
-def create_playlist_file(channel_name, playlist_urls, folder="channels"):
+def download_icon(channel_name, icon_url, folder):
     """
-    Creates a playlist file in extended M3U format for the given channel.
+    Downloads a channel's icon image and saves it alongside its playlist.
 
     Args:
         channel_name (str): The name of the channel.
-        playlist_urls (list): A list of playlist URLs for the channel.
-        folder (str): The folder to save the playlist file.
+        icon_url (str): The URL of the icon image to download.
+        folder (str): The folder to save the icon image in.
+
+    Returns:
+        str: The icon's file name (relative to folder), or None if the
+        download failed.
     """
+    image_ext = os.path.splitext(icon_url)[1] or '.png'
+    file_name = f"{channel_name}{image_ext}"
+    try:
+        response = requests.get(icon_url)
+        response.raise_for_status()
+    except HTTPError as http_err:
+        print(f'HTTP error downloading icon for {channel_name}:\n {http_err}')
+        return None
+    except Exception as err:
+        print(f'Other error downloading icon for {channel_name}: {err}')
+        return None
+
+    with open(os.path.join(folder, file_name), 'wb') as f:
+        f.write(response.content)
+
+    return file_name
+
+
+def create_playlist_file(channel_name, channel_data, folder, icon_size):
+    """
+    Creates a playlist file in extended M3U format for the given channel,
+    downloading and referencing its icon image if available.
+
+    Args:
+        channel_name (str): The name of the channel.
+        channel_data (dict): 'urls' (playlist URLs) and 'icon_urls' (by size).
+        folder (str): The folder to save the playlist file and icon in.
+        icon_size (int): Which icon size (120, 256, or 512) to download.
+    """
+    icon_url = channel_data['icon_urls'].get(icon_size)
+    icon_file_name = download_icon(channel_name, icon_url, folder) if icon_url else None
+
     file_name = os.path.join(folder, f"{channel_name}.m3u")
     with open(file_name, 'w') as f:
         f.write(f"#EXTM3U\n#EXTINF:-1,{channel_name}\n")
-        for url in playlist_urls:
+        if icon_file_name:
+            f.write(f"#EXTIMG:{icon_file_name}\n")
+        for url in channel_data['urls']:
             f.write(f"{url}\n")
 
 
-url = "https://somafm.com/channels.json"
-response = get_channels(url)
-channel_playlists = get_playlists(response)
+def main():
+    parser = argparse.ArgumentParser(description='Fetch SomaFM channel playlists and icons.')
+    parser.add_argument('--size', type=int, choices=sorted(ICON_SIZES), default=120,
+                         help='Channel icon size in pixels to download (default: 120)')
+    args = parser.parse_args()
 
-# Create the channels folder if it does not exist
-if not os.path.exists("channels"):
-    os.makedirs("channels")
+    folder = "playlists"
+    if not os.path.exists(folder):
+        os.makedirs(folder)
 
-for channel_name, playlist_urls in channel_playlists.items():
-    create_playlist_file(channel_name, playlist_urls)
+    url = "https://somafm.com/channels.json"
+    response = get_channels(url)
+    channel_playlists = get_playlists(response)
+
+    for channel_name, channel_data in channel_playlists.items():
+        create_playlist_file(channel_name, channel_data, folder, args.size)
+
+
+if __name__ == "__main__":
+    main()
 


### PR DESCRIPTION
## Summary
- Rename the output folder from `channels` to `playlists`, matching `iheart-radio`/`tunein-radio`; `.gitignore` updated accordingly (also now ignores `__pycache__/`).
- SomaFM's `channels.json` exposes each channel's icon at three sizes (`image`=120px, `largeimage`=256px, `xlimage`=512px). The script now downloads the icon alongside each playlist and references it via `#EXTIMG:`, matching `iheart.pl`/`tunein.pl`'s convention.
- Add `--size {120,256,512}` to choose which icon size to download, defaulting to 120px.

## Test plan
- [x] `python3 -m py_compile` check
- [x] Ran end-to-end against the live SomaFM API with default size (120px) and `--size 512` — verified actual downloaded image dimensions match with Pillow
- [x] Verified an invalid `--size` value is rejected by argparse