### PR TITLE
Require -d/--download to run iheart.pl and tunein.pl

### DIFF
--- a/iheart-radio/README.md
+++ b/iheart-radio/README.md
@@ -23,12 +23,12 @@ sudo cpanm StreamFinder::IHeartRadio
 
 Ensure you have the StreamFinder::IHeartRadio Perl module installed to utilize this script effectively.
 
-Run the script with appropriate arguments or configuration to fetch station URLs, generate M3U playlists, and gather associated station information.
+`--download` (or `-d`) is required to actually fetch anything; running the script with no arguments (or without `-d`) just prints usage and exits.
 
 iheart.com intermittently serves a page without the embedded stream data it needs, so a station may fail even though it's valid. Each station is retried automatically up to 3 times before being skipped; override this with `--retries=N` (or `-r N`). Pass `--skip-existing` (or `-s`) to also let you re-run the script multiple times without redoing stations that already succeeded in a previous run:
 
 ```
-perl iheart.pl -s -r 5
+perl iheart.pl -d -s -r 5
 ```
 
 Completed stations are tracked as marker files under `playlists/.completed/`; delete that directory (or an individual marker) to force a station to be re-fetched.

--- a/iheart-radio/iheart.pl
+++ b/iheart-radio/iheart.pl
@@ -29,20 +29,38 @@ use File::Path qw(make_path);   # For managing directories
 # so a station lookup that fails once may succeed on a retry.
 use constant RETRY_DELAY_SECONDS => 3;
 
+my $USAGE = <<"EOF";
+Usage: $0 -d [--skip-existing|-s] [--retries|-r N] [--stations|-f FILE]
+
+  -d, --download        Fetch stations and write playlists/images (required; nothing else does this)
+  -s, --skip-existing    Skip stations already completed in a prior run
+  -r, --retries N        Attempts per station before giving up (default: 3)
+  -f, --stations FILE    Station list file (default: stations.txt next to this script)
+EOF
+
 # With --skip-existing, stations already completed in a prior run are left
 # untouched instead of being re-fetched, so the script can be re-run as many
 # times as needed to pick up the stations iheart.com failed on previously.
 # --retries overrides how many attempts each station gets (default: 3).
 # --stations points at the station list file (default: stations.txt next to this script).
+# --download is required to actually run; with no arguments (or without
+# --download), the script just prints usage and exits.
 my $skipExisting = 0;
 my $maxAttempts = 3;
 my $stationsFile = "$RealBin/stations.txt";
+my $download = 0;
 GetOptions(
     'skip-existing|s' => \$skipExisting,
     'retries|r=i'     => \$maxAttempts,
     'stations|f=s'    => \$stationsFile,
-) or die "Usage: $0 [--skip-existing|-s] [--retries|-r N] [--stations|-f FILE]\n";
+    'download|d'      => \$download,
+) or die $USAGE;
 die "--retries must be a positive integer\n" unless $maxAttempts > 0;
+
+unless ($download) {
+    print $USAGE;
+    exit 0;
+}
 
 my $playlistDir = "./playlists";  # Directory to store playlists
 make_path($playlistDir);

--- a/tunein-radio/README.md
+++ b/tunein-radio/README.md
@@ -23,12 +23,12 @@ sudo cpanm StreamFinder::Tunein
 
 Ensure you have the StreamFinder::Tunein Perl module installed to utilize this script effectively.
 
-Run the script with appropriate arguments or configuration to fetch station URLs, generate M3U playlists, and gather associated station information.
+`--download` (or `-d`) is required to actually fetch anything; running the script with no arguments (or without `-d`) just prints usage and exits.
 
 Each station is retried automatically up to 3 times before being skipped; override this with `--retries=N` (or `-r N`). Pass `--skip-existing` (or `-s`) to re-run the script multiple times without redoing stations that already succeeded in a previous run:
 
 ```
-perl tunein.pl -s -r 5
+perl tunein.pl -d -s -r 5
 ```
 
 Completed stations are tracked as marker files under `playlists/.completed/`; delete that directory (or an individual marker) to force a station to be re-fetched.

--- a/tunein-radio/tunein.pl
+++ b/tunein-radio/tunein.pl
@@ -27,20 +27,38 @@ use LWP::Simple;          # For downloading station images
 # lookup that fails once may succeed on a retry.
 use constant RETRY_DELAY_SECONDS => 3;
 
+my $USAGE = <<"EOF";
+Usage: $0 -d [--skip-existing|-s] [--retries|-r N] [--stations|-f FILE]
+
+  -d, --download        Fetch stations and write playlists/images (required; nothing else does this)
+  -s, --skip-existing    Skip stations already completed in a prior run
+  -r, --retries N        Attempts per station before giving up (default: 3)
+  -f, --stations FILE    Station list file (default: stations.txt next to this script)
+EOF
+
 # With --skip-existing, stations already completed in a prior run are left
 # untouched instead of being re-fetched, so the script can be re-run as many
 # times as needed to pick up any stations that failed previously.
 # --retries overrides how many attempts each station gets (default: 3).
 # --stations points at the station list file (default: stations.txt next to this script).
+# --download is required to actually run; with no arguments (or without
+# --download), the script just prints usage and exits.
 my $skipExisting = 0;
 my $maxAttempts = 3;
 my $stationsFile = "$RealBin/stations.txt";
+my $download = 0;
 GetOptions(
     'skip-existing|s' => \$skipExisting,
     'retries|r=i'     => \$maxAttempts,
     'stations|f=s'    => \$stationsFile,
-) or die "Usage: $0 [--skip-existing|-s] [--retries|-r N] [--stations|-f FILE]\n";
+    'download|d'      => \$download,
+) or die $USAGE;
 die "--retries must be a positive integer\n" unless $maxAttempts > 0;
+
+unless ($download) {
+    print $USAGE;
+    exit 0;
+}
 
 # Create playlists directory if it doesn't exist
 my $playlistDir = 'playlists';


### PR DESCRIPTION
## Summary
- Both scripts now print usage and exit if run with no arguments, or without `-d`/`--download` — nothing is fetched until you explicitly ask for it.
- `-d`/`--download` is the new gate; existing `-s`/`--skip-existing`, `-r`/`--retries`, `-f`/`--stations` flags are unchanged.
- somafm's `soma_fm_playlist_fetcher.py` gets the same `-d` treatment in its own open PR (#45).

## Test plan
- [x] `perl -c` syntax check on both scripts
- [x] Verified no-args prints usage and creates no files for both
- [x] Verified `-d` actually triggers the fetch for both (against live iheart.com/tunein.com)