### PR TITLE
Require -d/--download to run somafm's playlist fetcher

### DIFF
--- a/somafm/README.md
+++ b/somafm/README.md
@@ -20,13 +20,15 @@ This Python script fetches the playlist URLs of SomaFM channels with the highest
 4. Run the script:
 
    ```
-   python soma_fm_playlist_fetcher.py
+   python soma_fm_playlist_fetcher.py -d
    ```
+
+   `--download` (or `-d`) is required to actually fetch anything; running the script with no arguments (or without `-d`) just prints usage and exits.
 
    Each channel's icon is downloaded at 120px by default; pass `--size` (or `-s`) to choose 256px or 512px instead:
 
    ```
-   python soma_fm_playlist_fetcher.py -s 512
+   python soma_fm_playlist_fetcher.py -d -s 512
    ```
 
 5. The script will create a folder named `playlists` in the current directory and save individual M3U playlists and icon images for each SomaFM channel in that folder.

--- a/somafm/soma_fm_playlist_fetcher.py
+++ b/somafm/soma_fm_playlist_fetcher.py
@@ -130,9 +130,15 @@ def create_playlist_file(channel_name, channel_data, folder, icon_size):
 
 def main():
     parser = argparse.ArgumentParser(description='Fetch SomaFM channel playlists and icons.')
+    parser.add_argument('-d', '--download', action='store_true',
+                         help='Fetch channels and write playlists/icons (required; nothing else does this)')
     parser.add_argument('-s', '--size', type=int, choices=sorted(ICON_SIZES), default=120,
                          help='Channel icon size in pixels to download (default: 120)')
     args = parser.parse_args()
+
+    if not args.download:
+        parser.print_help()
+        return
 
     folder = "playlists"
     if not os.path.exists(folder):


### PR DESCRIPTION
## Summary
Completes what #46 did for iheart.pl/tunein.pl, applied to somafm's script. This commit was originally pushed to the `feature/somafm-icons-playlists-rename` branch, but PR #45 had already been merged by the time it landed, so it never made it into `main`. Re-applying it here.

- `-d`/`--download` is now required to actually run; with no arguments (or without `-d`), the script prints usage and exits instead of fetching every channel.

## Test plan
- [x] `python3 -m py_compile` check
- [x] Verified no-args prints usage and creates no files
- [x] Verified `-d` still triggers the fetch correctly