### PR TITLE
Standardize README License sections across the repo

### DIFF
--- a/iheart-radio/README.md
+++ b/iheart-radio/README.md
@@ -41,5 +41,7 @@ By default the playlist/image filenames are derived from the station's title as 
 
 ### License
 
-This project is licensed under the **GNU General Public License v3.0**. For more information, see [LICENSE](../LICENSE).
+This project is licensed under the **GNU General Public License v3.0**.
+
+See [LICENSE](../LICENSE) for more information.
 

--- a/lastfm-love/README.md
+++ b/lastfm-love/README.md
@@ -10,5 +10,8 @@ API_SECRET
 username  
 password_hash (with an md5 hash of your password)  
 
-***
-#### License: [GPLv3](../LICENSE)
+## License
+
+This project is licensed under the **GNU General Public License v3.0**.
+
+See [LICENSE](../LICENSE) for more information.

--- a/mpd-notifier/README.md
+++ b/mpd-notifier/README.md
@@ -4,5 +4,8 @@
 - Will notify user if mpd is currently stopped. 
 - Will show the artist, title, albumart with (paused) appended at the end when mpd is paused.  
 
-***
-#### License: [GPLv3](../LICENSE)
+## License
+
+This project is licensed under the **GNU General Public License v3.0**.
+
+See [LICENSE](../LICENSE) for more information.

--- a/mpd-queue-shuffle/README.md
+++ b/mpd-queue-shuffle/README.md
@@ -70,4 +70,8 @@ If any of these tools are missing, the script will attempt to install them autom
    - The script will automatically check for and install the following utilities if they are not already installed:
      - `mpc`, `awk`, `shuf`, `ripgrep`, `parallel`.
 
-#### License: [GPLv3](../LICENSE)
+## License
+
+This project is licensed under the **GNU General Public License v3.0**.
+
+See [LICENSE](../LICENSE) for more information.

--- a/somafm/README.md
+++ b/somafm/README.md
@@ -39,5 +39,8 @@ This Python script fetches the playlist URLs of SomaFM channels with the highest
 - `README.md`: This README file providing instructions and information about the script.
 - `playlists/`: Folder containing the generated M3U playlist files and channel icon images for each SomaFM channel.
 
-***
-#### License: [GPLv3](../LICENSE)
+## License
+
+This project is licensed under the **GNU General Public License v3.0**.
+
+See [LICENSE](../LICENSE) for more information.

--- a/tunein-radio/README.md
+++ b/tunein-radio/README.md
@@ -41,5 +41,7 @@ By default the playlist/image filenames are derived from the station's title as 
 
 ### License
 
-This project is licensed under the **GNU General Public License v3.0**. For more information, see [LICENSE](../LICENSE).
+This project is licensed under the **GNU General Public License v3.0**.
+
+See [LICENSE](../LICENSE) for more information.
 

--- a/volume/README.md
+++ b/volume/README.md
@@ -9,5 +9,8 @@ Simple commands allow you to adjust the volume up, down, or to a specific level.
 | --- | --- |
 | **[volume (python-mpd based)](./python-mpd/)** | Volume scripts using the python library python-mpd. |
 | **[volume (mpc cli based)](./mpc/)** | Volume scripts directly using the mpc client directly. |
-***
-#### License: [GPLv3](../LICENSE)
+## License
+
+This project is licensed under the **GNU General Public License v3.0**.
+
+See [LICENSE](../LICENSE) for more information.

--- a/volume/mpc/README.md
+++ b/volume/mpc/README.md
@@ -16,5 +16,8 @@ apt install mpc
 ```
 If you aren't using a Debian/Ubuntu based system consult your distrobution for package name and install method.
 
-***
-#### License: [GPLv3](../../LICENSE)
+## License
+
+This project is licensed under the **GNU General Public License v3.0**.
+
+See [LICENSE](../../LICENSE) for more information.

--- a/volume/python-mpd/README.md
+++ b/volume/python-mpd/README.md
@@ -14,5 +14,8 @@ python-mpd2
 ```
 pip install python-mpd2
 ```
-***
-#### License: [GPLv3](../../LICENSE)
+## License
+
+This project is licensed under the **GNU General Public License v3.0**.
+
+See [LICENSE](../../LICENSE) for more information.


### PR DESCRIPTION
## Summary
Audited all 12 README.md files in the repo against the standard License section format (heading + "GNU General Public License v3.0" statement + separate "See [LICENSE](path) for more information." line) and section ordering (License last).

- `lastfm-love`, `mpd-notifier`, `mpd-queue-shuffle`, `somafm`, `volume`, `volume/mpc`, `volume/python-mpd`: converted from the old inline `#### License: [GPLv3](path)` one-liner to the full section, at the correct relative LICENSE path for each file's depth.
- `iheart-radio`, `tunein-radio`: normalized the one-sentence wording to match the two-line template used elsewhere.
- `mpd-find-dup`, `mpd_rewind_daemon`, and the root README already matched the template and needed no changes; License was already the last section in every file, so no reordering was needed anywhere.

## Test plan
- [x] Manually reviewed every README.md's heading list and License section before and after