### PR TITLE
mpd-notifier: show real artist on compilations

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,4 +1,1 @@
 # mpd-scripts - TODO
-## mpd-notifier
- - Take into account Compilitions and Artwork by using ALBUMARTIST where ARTIST != ALBUMARTIST for notifications on the notifier script
- - Make sure to use Artist info on compilations for notifications

--- a/mpd-notifier/mpd-notifier.sh
+++ b/mpd-notifier/mpd-notifier.sh
@@ -25,8 +25,11 @@ if [ ! -f "$fallback_image" ]; then
     cp "$(dirname "$0")/unknown.jpg" "$cache_dir"
 fi
 
-# Get all the info needed to create the notify-send message: album artist, album, title, cover image.
-output=$(mpc -f "%title%\n%albumartist%\n%album%\n%file%" current)
+# Get all the info needed to create the notify-send message: title, artist,
+# album artist, album, cover image. Artist and album artist are fetched
+# separately so compilations (where they differ) can show the real track
+# artist instead of the album's "Various Artists" album artist.
+output=$(mpc -f "%title%\n%artist%\n%albumartist%\n%album%\n%file%" current)
 
 # Get MPD status
 if [ -n "${MPD_HOST}" ]; then
@@ -55,9 +58,18 @@ if [ $? -ne 1 ]; then
     array[1]=$(echo "${array[1]}" | sed 's/\&/\&amp\;/')
     array[2]=$(echo "${array[2]}" | sed 's/\&/\&amp\;/')
     array[3]=$(echo "${array[3]}" | sed 's/\&/\&amp\;/')
+    array[4]=$(echo "${array[4]}" | sed 's/\&/\&amp\;/')
+
+    # On compilations, artist (per-track) differs from album artist (e.g.
+    # "Various Artists"); prefer the real artist for the notification.
+    if [ -n "${array[2]}" ] && [ "${array[2]}" != "${array[3]}" ]; then
+        display_artist="${array[2]}"
+    else
+        display_artist="${array[3]}"
+    fi
 
     if [ -z "${MPD_HOST}" ]; then
-        local_image="$(dirname "$dir${array[4]}")/cover.jpg"
+        local_image="$(dirname "$dir${array[5]}")/cover.jpg"
         cache_image="$cache_dir/cover.jpg"
         # Check if cover.jpg exists locally, if not, use the fallback image directly
         if [ -f "$local_image" ]; then
@@ -71,17 +83,17 @@ fi
 # Construct notify-send command based on image availability
 if [ -f "$cache_image" ]; then
     if [ "$status" == "playing" ]; then
-        notify-send "${array[1]}" "${array[2]}\n${array[3]}" -t "$notify_duration" -i "$cache_image"
+        notify-send "${array[1]}" "${display_artist}\n${array[4]}" -t "$notify_duration" -i "$cache_image"
     elif [ "$status" == "paused" ]; then
-        notify-send "${array[1]}" "${array[2]}\n${array[3]} ($status)" -t "$notify_duration" -i "$cache_image"
+        notify-send "${array[1]}" "${display_artist}\n${array[4]} ($status)" -t "$notify_duration" -i "$cache_image"
     else
         notify-send -i "$cache_image" -t "$notify_duration" "MPD client $status"
     fi
 else
     if [ "$status" == "playing" ]; then
-        notify-send "${array[1]}" "${array[2]}\n${array[3]}" -t "$notify_duration" -i "$fallback_image"
+        notify-send "${array[1]}" "${display_artist}\n${array[4]}" -t "$notify_duration" -i "$fallback_image"
     elif [ "$status" == "paused" ]; then
-        notify-send "${array[1]}" "${array[2]}\n${array[3]} ($status)" -t "$notify_duration" -i "$fallback_image"
+        notify-send "${array[1]}" "${display_artist}\n${array[4]} ($status)" -t "$notify_duration" -i "$fallback_image"
     else
         notify-send -i "${fallback_image}" -t "$notify_duration" "MPD client $status"
     fi


### PR DESCRIPTION
## Summary
Addresses both items in `docs/TODO.md`:
```
## mpd-notifier
 - Take into account Compilitions and Artwork by using ALBUMARTIST where ARTIST != ALBUMARTIST for notifications on the notifier script
 - Make sure to use Artist info on compilations for notifications
```

The script previously only queried `%albumartist%` from `mpc`, so every track on a compilation notified with the album artist (e.g. "Various Artists") instead of the actual performer. It now fetches `%artist%` too and uses it whenever it differs from `%albumartist%`, falling back to `%albumartist%` otherwise. Album art lookup is unaffected since it already derives the cover path from the track's file path rather than either artist field.

`docs/TODO.md` is cleared since both items are now done.

## Test plan
- [x] `bash -n` syntax check
- [x] Stubbed `mpc`/`notify-send` and verified three cases: compilation (artist != album artist) shows the real artist, a normal album (artist == album artist) is unaffected, and an empty `%artist%` tag falls back to album artist