### PR TITLE
Fix mpd-queue-shuffle: broken artist-limiting, dead ripgrep/parallel path, add config

### DIFF
--- a/mpd-queue-shuffle/.gitignore
+++ b/mpd-queue-shuffle/.gitignore
@@ -1,0 +1,2 @@
+# Ignore a locally-created live config; only mpd-queue-shuffle.conf.example is tracked
+mpd-queue-shuffle.conf

--- a/mpd-queue-shuffle/README.md
+++ b/mpd-queue-shuffle/README.md
@@ -7,29 +7,42 @@ This script generates a random playlist from a local music directory and saves i
 - **Filter by Artist**: The script filters tracks by artist and limits how many tracks from each artist are included.
 - **Random Track Selection**: If the filtered list is smaller than the desired number of tracks, the script fills the playlist with additional random tracks from the music directory.
 - **Playlist Management**: If the playlist already exists in MPC, it will be removed before creating a new one.
-- **Automatic Tool Installation**: The script checks for required utilities (`mpc`, `awk`, `shuf`, `ripgrep`, `parallel`) and installs them if they are missing.
+- **Tool Installation, with confirmation**: The script checks for required utilities (`mpc`, `awk`, `shuf`, and `ripgrep`/`parallel` unless `--fallback` is used) and offers to install any that are missing before proceeding.
 
+## Requirements
 
+- `mpc`
+- `awk`, `shuf` (present on virtually any Linux system by default)
+- `ripgrep`, `parallel` (optional, used for faster filtering unless `--fallback` is passed)
+
+If any of these are missing, the script will offer to install them via `apt` (confirming first, unless `-y`/`--yes` is passed).
+
+## Configuration
+
+Settings live in `~/.config/mpd-queue-shuffle/mpd-queue-shuffle.conf`, seeded automatically from [`mpd-queue-shuffle.conf.example`](./mpd-queue-shuffle.conf.example) the first time you run the script. Edit the copy in `~/.config/mpd-queue-shuffle/`, not the template.
+
+- `MUSIC_DIR`: local music directory containing MP3 files -- must match MPD's own `music_directory` so the generated playlist's paths resolve correctly.
+- `PLAYLIST_DIR`: directory where `mpc` saves/loads playlists (MPD's `playlist_directory`).
+- `DEFAULT_TARGET_TRACK_COUNT`: number of tracks in the playlist when `-c` isn't passed. Default `16000`.
+- `DEFAULT_PLAYLIST_NAME`: playlist name when `-p` isn't passed. Default `random_playlist`.
+
+The script won't run until `MUSIC_DIR`/`PLAYLIST_DIR` have been changed from their placeholder values.
 
 ## Usage
 
 You can customize the playlist by specifying the target number of tracks and the playlist name using the following options:
 
-- `-c` : Custom number of tracks in the playlist (e.g., `-c 20000`).
-- `-p` : Custom playlist name (e.g., `-p my_playlist`).
+- `-c TRACK_COUNT`: Set the number of tracks in the playlist (e.g., `-c 20000`).
+- `-p PLAYLIST_NAME`: Set the name of the playlist (e.g., `-p my_playlist`).
+- `-f`, `--fallback`: Use `grep`/`shuf` instead of `ripgrep`/`parallel`, even if the latter are installed.
+- `-y`, `--yes`: Install any missing required tools without prompting first.
 
-If no options are provided, the script defaults to creating a playlist with 16,000 tracks named `random_playlist`.
-
-### Command Line Options
-
-- `-c TRACK_COUNT`: Set the number of tracks in the playlist. Default is 16,000.
-- `-p PLAYLIST_NAME`: Set the name of the playlist. Default is `random_playlist`.
-- `--fallback`: Use basic tools (`grep` and `shuf`) instead of `ripgrep` and `parallel`.
+If `-c`/`-p` aren't provided, the script uses `DEFAULT_TARGET_TRACK_COUNT`/`DEFAULT_PLAYLIST_NAME` from the config file.
 
 Example usage:
 
 ```bash
-./mpd-queue-shuf.sh -c 15000 -p my_custom_playlist
+./mpd-queue-shuffle.sh -c 15000 -p my_custom_playlist
 ```
 
 ## Example Output
@@ -37,38 +50,6 @@ Example usage:
 ```bash
 Random playlist of 15000 tracks created and saved as 'random_playlist'.
 ```
-
-## Prerequisites
-
-Before running the script, ensure that the following utilities are installed:
-
-- `mpc` (Music Player Client)
-- `awk` (Text processing tool)
-- `shuf` (Shuffling command)
-- `ripgrep` (Search tool, optional for better performance)
-- `parallel` (For parallel processing, optional for better performance)
-
-If any of these tools are missing, the script will attempt to install them automatically.
-
-## Setup
-
-1. **Configure the Music Directory**:
-   - Set the `MUSIC_DIR` variable to point to your local music directory containing MP3 files.
-   - Example:
-     ```bash
-     MUSIC_DIR="/path/to/your/music/directory/"
-     ```
-
-2. **Configure the Playlist Directory**:
-   - Set the `PLAYLIST_DIR` variable to the path where MPC saves its playlists.
-   - Example:
-     ```bash
-     PLAYLIST_DIR="/path/to/your/mpc/playlists/directory/"
-     ```
-
-3. **Install Required Tools**:
-   - The script will automatically check for and install the following utilities if they are not already installed:
-     - `mpc`, `awk`, `shuf`, `ripgrep`, `parallel`.
 
 ## License
 

--- a/mpd-queue-shuffle/mpd-queue-shuffle.conf.example
+++ b/mpd-queue-shuffle/mpd-queue-shuffle.conf.example
@@ -1,0 +1,16 @@
+# mpd-queue-shuffle configuration
+#
+# Copied to ~/.config/mpd-queue-shuffle/mpd-queue-shuffle.conf on first run
+# if that file doesn't already exist. Edit the copy there, not this template.
+
+# Local music directory containing MP3 files (must match MPD's own
+# music_directory so the generated playlist's paths resolve correctly).
+MUSIC_DIR="/path/to/your/music/directory/"
+
+# Directory where mpc saves/loads playlists (MPD's playlist_directory).
+PLAYLIST_DIR="/path/to/your/mpc/playlists/directory/"
+
+# Default number of tracks in the generated playlist, and its name,
+# when -c/-p aren't passed on the command line.
+DEFAULT_TARGET_TRACK_COUNT=16000
+DEFAULT_PLAYLIST_NAME="random_playlist"

--- a/mpd-queue-shuffle/mpd-queue-shuffle.sh
+++ b/mpd-queue-shuffle/mpd-queue-shuffle.sh
@@ -2,7 +2,7 @@
 
 # Description:
 # This script generates a random playlist of tracks from a local music directory using MPC.
-# It filters tracks by artist, limits the number of tracks from each artist, and saves the 
+# It filters tracks by artist, limits the number of tracks from each artist, and saves the
 # generated playlist as an M3U file in the specified playlist directory.
 #
 # The script:
@@ -10,90 +10,151 @@
 # - Filters tracks by artist and limits the number of tracks based on the artist's total.
 # - If the total number of filtered tracks is less than the target count, it fills up the list
 #   with additional random tracks from the library.
-# - Removes the base directory path when saving the playlist.
 # - Checks if the playlist already exists in MPC and deletes it before creating a new one.
 #
-# Important:
-# Before running the script, ensure that the following variables are correctly set:
-# - `MUSIC_DIR`: Path to your local music directory containing MP3 files.
-# - `PLAYLIST_DIR`: Path to the directory where MPC saves its playlists (typically with `.m3u` extension).
+# Configuration:
+# MUSIC_DIR, PLAYLIST_DIR, and the defaults below live in
+# ~/.config/mpd-queue-shuffle/mpd-queue-shuffle.conf, seeded from
+# mpd-queue-shuffle.conf.example on first run.
 #
 # Usage:
 # - You can specify a custom track count and playlist name with the `-c` and `-p` options respectively.
-# - If not specified, the script defaults to creating a playlist with 16,000 tracks named "random_playlist".
+# - If not specified, the script defaults to the track count/playlist name from the config file.
+# - Pass --fallback (or -f) to use grep/shuf instead of ripgrep/parallel even if they're installed.
+# - Pass -y/--yes to install any missing required tools without prompting first.
 
-# Editable variables
-# Set the path to your local music directory
-MUSIC_DIR="/media/william/NewData/Music/MP3B/"
+set -e  # Exit on error
 
-# Set the path to your MPC playlists directory
-PLAYLIST_DIR="/media/william/NewData/homelab/mpd-alsa-docker/data/.mpd/playlists/"
+# Config lives in ~/.config/mpd-queue-shuffle/mpd-queue-shuffle.conf, seeded
+# from the mpd-queue-shuffle.conf.example template shipped alongside this
+# script on first run.
+CONFIG_DIR="$HOME/.config/mpd-queue-shuffle"
+CONFIG_FILE="$CONFIG_DIR/mpd-queue-shuffle.conf"
 
-# Default number of tracks in the playlist
-DEFAULT_TARGET_TRACK_COUNT=16000
+if [ ! -f "$CONFIG_FILE" ]; then
+    mkdir -p "$CONFIG_DIR"
+    cp "$(dirname "$0")/mpd-queue-shuffle.conf.example" "$CONFIG_FILE"
+    echo "Created $CONFIG_FILE -- edit it with your music/playlist directories, then run this again."
+    exit 1
+fi
 
-# Default playlist name
-DEFAULT_PLAYLIST_NAME="random_playlist"
+# shellcheck source=mpd-queue-shuffle.conf.example
+source "$CONFIG_FILE"
 
-# Temporary files for storing track lists
-TRACK_LIST=$(mktemp)
-FILTERED_TRACK_LIST=$(mktemp)
-ADDITIONAL_TRACK_LIST=$(mktemp)
+if [[ "$MUSIC_DIR" == "/path/to/your/music/directory/" || "$PLAYLIST_DIR" == "/path/to/your/mpc/playlists/directory/" ]]; then
+    echo "Error: $CONFIG_FILE still has placeholder MUSIC_DIR/PLAYLIST_DIR values. Edit it first."
+    exit 1
+fi
 
-# Function to install required packages if not already installed
-install_package() {
-    sudo apt install -y "$1"
-}
+# Ensure MUSIC_DIR has a trailing slash, so stripping it from found paths
+# below always leaves a clean relative path (needed for correct per-artist
+# grouping -- see TRACK_LIST below).
+[[ "$MUSIC_DIR" == */ ]] || MUSIC_DIR="$MUSIC_DIR/"
 
-# Function to check and install required tools
-install_required_tools() {
-    for cmd in mpc awk shuf; do
-        if ! command -v "$cmd" &>/dev/null; then
-            echo "$cmd is required but not installed. Installing..."
-            install_package "$cmd"
-        fi
-    done
+# Parse command-line arguments. --fallback/-f and -y/--yes are handled
+# separately first since getopts doesn't support long options, then
+# whatever's left goes through getopts for -c/-p.
+FALLBACK_MODE=false
+ASSUME_YES=false
+ARGS=()
+for arg in "$@"; do
+    case "$arg" in
+        --fallback) FALLBACK_MODE=true ;;
+        --yes) ASSUME_YES=true ;;
+        *) ARGS+=("$arg") ;;
+    esac
+done
+set -- "${ARGS[@]}"
 
-    # Check for optional tools and install them if not installed
-    for cmd in rg parallel; do
-        if ! command -v "$cmd" &>/dev/null; then
-            echo "$cmd is not installed. Installing..."
-            install_package "$cmd"
-        fi
-    done
-}
-
-# Install the required tools
-install_required_tools
-
-# Parse command-line arguments using getopts
-while getopts "c:p:" opt; do
+while getopts "c:p:fy" opt; do
     case $opt in
         c) TARGET_TRACK_COUNT="$OPTARG" ;;
         p) PLAYLIST_NAME="$OPTARG" ;;
-        *) echo "Usage: $0 [-c track_count] [-p playlist_name]" ;;
+        f) FALLBACK_MODE=true ;;
+        y) ASSUME_YES=true ;;
+        *) echo "Usage: $0 [-c track_count] [-p playlist_name] [-f|--fallback] [-y|--yes]"; exit 1 ;;
     esac
 done
 
 # Set defaults if arguments are not provided
 TARGET_TRACK_COUNT=${TARGET_TRACK_COUNT:-$DEFAULT_TARGET_TRACK_COUNT}
 PLAYLIST_NAME=${PLAYLIST_NAME:-$DEFAULT_PLAYLIST_NAME}
-FALLBACK_MODE=false
 
-# Check for --fallback argument
-if [[ "$1" == "--fallback" ]]; then
-    FALLBACK_MODE=true
+if [ "$FALLBACK_MODE" = true ]; then
     echo "Fallback mode enabled: Using grep and shuf instead of ripgrep and parallel."
 fi
+
+# Checks for required tools (mpc, awk, shuf), and ripgrep/parallel unless
+# --fallback was given (no point installing them if they won't be used).
+# Prompts before installing anything unless -y/--yes was given.
+check_required_tools() {
+    local required=(mpc awk shuf)
+    local optional=()
+    if [ "$FALLBACK_MODE" != true ]; then
+        optional+=(rg parallel)
+    fi
+
+    local missing=()
+    for cmd in "${required[@]}" "${optional[@]}"; do
+        command -v "$cmd" &>/dev/null || missing+=("$cmd")
+    done
+
+    if [ "${#missing[@]}" -eq 0 ]; then
+        return
+    fi
+
+    echo "Missing tools: ${missing[*]}"
+    if [ "$ASSUME_YES" != true ]; then
+        read -r -p "Install them now with apt (requires sudo)? [y/N] " reply
+        if [[ ! "$reply" =~ ^[Yy]$ ]]; then
+            echo "Cannot continue without these tools."
+            exit 1
+        fi
+    fi
+
+    for cmd in "${missing[@]}"; do
+        # apt's package name differs from the binary name for ripgrep.
+        local pkg="$cmd"
+        [ "$cmd" = "rg" ] && pkg="ripgrep"
+        sudo apt install -y "$pkg"
+    done
+}
+
+check_required_tools
+
+# Use ripgrep/parallel only if they're actually available and --fallback
+# wasn't requested.
+USE_RIPGREP=false
+USE_PARALLEL=false
+if [ "$FALLBACK_MODE" != true ]; then
+    command -v rg &>/dev/null && USE_RIPGREP=true
+    command -v parallel &>/dev/null && USE_PARALLEL=true
+fi
+
+# Bail out early with a clear error if MPD/mpc isn't reachable, rather than
+# doing all the scanning below and only failing at the final `mpc load`.
+if ! mpc status &>/dev/null; then
+    echo "Error: cannot reach MPD via mpc. Is it running and configured correctly?"
+    exit 1
+fi
+
+# Temporary files for storing track lists
+TRACK_LIST=$(mktemp)
+FILTERED_TRACK_LIST=$(mktemp)
+ADDITIONAL_TRACK_LIST=$(mktemp)
+ARTIST_LIMITS=$(mktemp)
+trap 'rm -f "$TRACK_LIST" "$FILTERED_TRACK_LIST" "$ADDITIONAL_TRACK_LIST" "$ARTIST_LIMITS"' EXIT
 
 # Clear the current MPC queue
 mpc clear
 
-# Fetch all available tracks in the music directory
-find "$MUSIC_DIR" -type f -iname "*.mp3" > "$TRACK_LIST"
+# Fetch all available tracks in the music directory, stored relative to
+# MUSIC_DIR (e.g. "ArtistName/Album/track.mp3") so the artist-grouping
+# below (and the final playlist paths) are correct.
+find "$MUSIC_DIR" -type f -iname "*.mp3" | sed "s|^$MUSIC_DIR||" > "$TRACK_LIST"
 
 # Count the number of tracks per artist, and limit how many from each artist can be included.
-awk -F"/" '{artists[$1]++} END {for (a in artists) print a, (artists[a] < 50 ? 5 : int(artists[a] * 0.10))}' "$TRACK_LIST" > artist_limits.txt
+awk -F"/" '{artists[$1]++} END {for (a in artists) print a, (artists[a] < 50 ? 5 : int(artists[a] * 0.10))}' "$TRACK_LIST" > "$ARTIST_LIMITS"
 
 declare -A artist_counts  # To keep track of how many tracks have been added per artist
 
@@ -114,7 +175,7 @@ while IFS= read -r line; do
             grep "^$artist_escaped/" "$TRACK_LIST" | shuf -n "$limit" >> "$FILTERED_TRACK_LIST"
         fi
     fi
-done < artist_limits.txt
+done < "$ARTIST_LIMITS"
 
 # Shuffle and limit the track count to the desired target
 TRACK_COUNT=$(wc -l < "$FILTERED_TRACK_LIST")
@@ -122,7 +183,6 @@ TRACK_COUNT=$(wc -l < "$FILTERED_TRACK_LIST")
 # If the filtered list contains fewer than TARGET_TRACK_COUNT, fill with random tracks
 if [ "$TRACK_COUNT" -lt "$TARGET_TRACK_COUNT" ]; then
     ADDITIONAL_COUNT=$((TARGET_TRACK_COUNT - TRACK_COUNT))
-    #Comment out Debug Statement: echo "Filling up with $ADDITIONAL_COUNT additional random tracks."
 
     # Create a list of additional tracks that excludes already added tracks
     grep -F -v -f "$FILTERED_TRACK_LIST" "$TRACK_LIST" > "$ADDITIONAL_TRACK_LIST"
@@ -138,15 +198,14 @@ fi
 # Remove playlist if it already exists (using mpc)
 mpc lsplaylists | grep -q "^$PLAYLIST_NAME$" && mpc rm "$PLAYLIST_NAME"
 
-# Save the new playlist by writing the tracks to the playlist directory
-# Remove the base music directory path from the track file paths
-sed "s|^$MUSIC_DIR||" "$FILTERED_TRACK_LIST" > "$PLAYLIST_DIR$PLAYLIST_NAME.m3u"
+# Save the new playlist by writing the (already MUSIC_DIR-relative) tracks
+# to the playlist directory.
+cp "$FILTERED_TRACK_LIST" "$PLAYLIST_DIR$PLAYLIST_NAME.m3u"
 
 # Add the tracks to MPC
-mpc load "$PLAYLIST_NAME"
-
-# Clean up temporary files
-rm "$TRACK_LIST" "$FILTERED_TRACK_LIST" "$ADDITIONAL_TRACK_LIST" artist_limits.txt
-
-    #Comment out Debug Statement: echo "Random playlist of $TARGET_TRACK_COUNT tracks created and saved as '$PLAYLIST_NAME'."
-
+if mpc load "$PLAYLIST_NAME"; then
+    echo "Random playlist of $TARGET_TRACK_COUNT tracks created and saved as '$PLAYLIST_NAME'."
+else
+    echo "Error: 'mpc load $PLAYLIST_NAME' failed; the .m3u file was written but MPD didn't load it." >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary

### Confirmed bugs fixed
- **Per-artist track limiting never actually worked.** `awk -F"/" '{artists[$1]++}...'` grouped on `$1` of paths from `find "$MUSIC_DIR" ...`, but since `MUSIC_DIR` is absolute, every line starts with `/`, so `$1` was always the empty string -- every track across every artist collapsed into one bucket. Verified empirically with a real test library (3 tracks across 2 artists all landed under a single `[]` key). Fixed by stripping `MUSIC_DIR` from paths right after `find`, so grouping/filtering happens on relative paths throughout. Re-verified against a 100/10/3-track-per-artist test library: the fix correctly caps the prolific artist at its computed limit instead of letting it dominate.
- **`USE_RIPGREP`/`USE_PARALLEL` were dead code.** Referenced in `if [ "$VAR" = true ]` checks but never assigned anywhere, so those branches were unreachable -- the script always used `grep`/`shuf` regardless of `--fallback` or whether `ripgrep`/`parallel` were installed. Now actually set based on tool availability and `--fallback`; confirmed via `bash -x` that `rg`/`parallel` are genuinely invoked when applicable, and that `--fallback` genuinely forces the `grep`/`shuf` path.
- **`install_package "rg"` would always fail** -- there's no apt package literally named `rg` (confirmed via `apt-cache show`), it's `ripgrep`.

### Other fixes
- Moved `MUSIC_DIR`/`PLAYLIST_DIR`/defaults to a config file (`mpd-queue-shuffle.conf.example`, seeded to `~/.config/mpd-queue-shuffle/`), matching the convention already used elsewhere in this repo; refuses to run with placeholder values.
- Added `-y`/`--yes` to skip the confirmation prompt before installing missing tools via `sudo apt` (previously silent/unconditional); `-f` as the short form of `--fallback`.
- Added a preflight `mpc status` check so an unreachable MPD fails fast with a clear message instead of after the full scan/filter pipeline.
- `artist_limits.txt` now uses `mktemp` (was read/written/removed in the current working directory) and all temp files are cleaned up via a trap on exit, matching the script's other temp files.
- Checks that `mpc load` actually succeeds before reporting success.

README documents the config file and new flags, and fixes the example command's typo (`mpd-queue-shuf.sh` -> `mpd-queue-shuffle.sh`).

## Test plan
- [x] `bash -n` syntax check
- [x] Ran end-to-end against a real local MPD instance with a controlled test library (ArtistA: 100 tracks, ArtistB: 10, ArtistC: 3)
- [x] Confirmed the generated playlist correctly limits ArtistA (capped during filtering, matching the `int(count*0.10)` formula) instead of dominating with all 100 tracks
- [x] Confirmed via `bash -x` that `rg`/`parallel` are genuinely used when installed and `--fallback` isn't passed, and that `--fallback` genuinely forces `grep`/`shuf`
- [x] Confirmed no leftover temp files after a run (cleanup trap works)
- [x] Confirmed re-running against an existing playlist name correctly removes it first (`mpc rm` then `mpc load`), including under `set -e`
- [x] Confirmed first-run config seeding with placeholder detection, and the MPD-unreachable preflight check