### PR TITLE
Fix mpd-find-dup: infinite loop on empty queue, hardcoded config

### DIFF
--- a/mpd-find-dup/.gitignore
+++ b/mpd-find-dup/.gitignore
@@ -1,0 +1,2 @@
+# Ignore a locally-created live config; only mpd-deduplicate-save-and-reload.conf.example is tracked
+mpd-deduplicate-save-and-reload.conf

--- a/mpd-find-dup/README.md
+++ b/mpd-find-dup/README.md
@@ -26,14 +26,14 @@ This script scans the current MPD queue and removes duplicate entries based on f
 #### Usage
 
 ```bash
-./mpd-remove-duplicates-queue.sh
+./mpd-remove-duplicates-queue.sh [-h|--help]
 ````
 
 #### What It Does
 
 1. Scans the MPD queue for the first duplicate file.
 2. Deletes the first occurrence of the duplicate.
-3. Repeats until no duplicates remain.
+3. Repeats until no duplicates remain (including an empty queue, which is reported as "no duplicates" rather than looping).
 
 #### Example Output
 
@@ -53,16 +53,17 @@ This script saves the current MPD queue to a `.m3u` playlist file, removes dupli
 
 #### Configuration
 
-Edit the following variable at the top of the script to match your environment:
+Settings live in `~/.config/mpd-find-dup/mpd-deduplicate-save-and-reload.conf`, seeded automatically from [`mpd-deduplicate-save-and-reload.conf.example`](./mpd-deduplicate-save-and-reload.conf.example) the first time you run the script. Edit the copy in `~/.config/mpd-find-dup/`, not the template.
 
-```bash
-PLAYLIST_DIR="/path/to/your/mpd/playlists/"
-```
+- `PLAYLIST_DIR`: directory where `mpc` saves/loads playlists. **Must match MPD's own `playlist_directory`** — `mpc save`/`load`/`rm` operate through MPD's own config, independent of this value, which is only used to edit the saved playlist file directly during the dedup step. If the two don't match, that step silently edits a different file than the one MPD actually reloads.
+- `PLAYLIST_NAME`: name of the playlist to save/reload (without the `.m3u` extension). Default `current_playlist`.
+
+The script won't run until `PLAYLIST_DIR` has been changed from its placeholder value.
 
 #### Usage
 
 ```bash
-./mpd-deduplicate-save-and-reload.sh
+./mpd-deduplicate-save-and-reload.sh [-h|--help]
 ```
 
 #### What It Does

--- a/mpd-find-dup/mpd-deduplicate-save-and-reload.conf.example
+++ b/mpd-find-dup/mpd-deduplicate-save-and-reload.conf.example
@@ -1,0 +1,15 @@
+# mpd-deduplicate-save-and-reload.conf
+#
+# Copied to ~/.config/mpd-find-dup/mpd-deduplicate-save-and-reload.conf on
+# first run if that file doesn't already exist. Edit the copy there, not
+# this template.
+
+# Directory where mpc saves/loads playlists. Must match MPD's own
+# playlist_directory -- mpc save/load/rm operate through MPD's own config,
+# independent of this value, which is only used to edit the saved playlist
+# file directly during the dedup step. If the two don't match, that step
+# edits a different file than the one MPD actually reloads.
+PLAYLIST_DIR="/path/to/your/mpd/playlists/"
+
+# Name of the playlist to save/reload (without the .m3u extension).
+PLAYLIST_NAME="current_playlist"

--- a/mpd-find-dup/mpd-deduplicate-save-and-reload.sh
+++ b/mpd-find-dup/mpd-deduplicate-save-and-reload.sh
@@ -3,20 +3,66 @@
 # Script: MPD Duplicate Removal (Save Current Queue to Playlist)
 # Purpose: This script saves the current MPD queue to a playlist, removes duplicates, and reloads the cleaned playlist.
 #
-# Variables:
-# - PLAYLIST_DIR: Directory where the playlists are stored.
-# - PLAYLIST_NAME: Name of the playlist to save (without .m3u extension).
-#
 # Usage:
-# 1. Set the PLAYLIST_DIR and PLAYLIST_NAME variables.
-# 2. Ensure MPD and MPC are installed and configured.
-# 3. Run the script.
+#   mpd-deduplicate-save-and-reload.sh [-h|--help]
+#
+# Configuration:
+#   PLAYLIST_DIR and PLAYLIST_NAME live in
+#   ~/.config/mpd-find-dup/mpd-deduplicate-save-and-reload.conf, seeded from
+#   mpd-deduplicate-save-and-reload.conf.example on first run.
+#
+#   PLAYLIST_DIR must match MPD's own configured playlist_directory: mpc
+#   save/load/rm operate through MPD's own config, independent of this
+#   script's PLAYLIST_DIR, which is only used to edit the saved playlist file
+#   directly during the dedup step. If the two don't match, that step edits
+#   a different file than the one MPD actually reloads.
 
-# Hardcoded playlist directory
-PLAYLIST_DIR="/path/to/your/mpd/playlists/"
+set -e
 
-# Name of the playlist to save (change this to your desired name)
-PLAYLIST_NAME="current_playlist"
+display_help() {
+    cat <<HELP
+Usage: $(basename "$0") [OPTIONS]
+
+Saves the current MPD queue to a playlist, removes duplicate entries from
+that playlist file (preserving order), then clears the queue and reloads
+the cleaned playlist.
+
+Options:
+  -h, --help  Show this help message.
+HELP
+    exit 0
+}
+
+case "${1:-}" in
+    -h|--help) display_help ;;
+    "") ;;
+    *)
+        echo "Unknown option: $1" >&2
+        display_help
+        ;;
+esac
+
+# Config lives in ~/.config/mpd-find-dup/mpd-deduplicate-save-and-reload.conf,
+# seeded from the mpd-deduplicate-save-and-reload.conf.example template
+# shipped alongside this script on first run.
+CONFIG_DIR="$HOME/.config/mpd-find-dup"
+CONFIG_FILE="$CONFIG_DIR/mpd-deduplicate-save-and-reload.conf"
+
+if [ ! -f "$CONFIG_FILE" ]; then
+    mkdir -p "$CONFIG_DIR"
+    cp "$(dirname "$0")/mpd-deduplicate-save-and-reload.conf.example" "$CONFIG_FILE"
+    echo "Created $CONFIG_FILE -- edit it with your playlist directory, then run this again."
+    exit 1
+fi
+
+# shellcheck source=mpd-deduplicate-save-and-reload.conf.example
+source "$CONFIG_FILE"
+
+if [[ "$PLAYLIST_DIR" == "/path/to/your/mpd/playlists/" ]]; then
+    echo "Error: $CONFIG_FILE still has a placeholder PLAYLIST_DIR value. Edit it first."
+    exit 1
+fi
+
 PLAYLIST_FILE="${PLAYLIST_DIR}/${PLAYLIST_NAME}.m3u"
 
 # Function: save_current_queue_to_playlist

--- a/mpd-find-dup/mpd-remove-duplicates-queue.sh
+++ b/mpd-find-dup/mpd-remove-duplicates-queue.sh
@@ -2,30 +2,60 @@
 
 # Script: MPD Duplicate Removal
 # Purpose: This script identifies and removes duplicate entries from an MPD playlist.
-# It finds the first duplicate based on file names, and removes it from the playlist.
+# It finds the first duplicate based on file path, and removes it from the playlist.
 # The script continues removing duplicates until there are no more left.
+#
+# Usage:
+#   mpd-remove-duplicates-queue.sh [-h|--help]
 #
 # Functions:
 # 1. mpd_first_duplicate: Identifies the position of the first duplicate file in the playlist.
 # 2. mpd_delete_duplicates: Loops through the playlist and deletes duplicates using the first function.
 #
-# Usage:
 # Run this script in an environment where MPD (Music Player Daemon) and MPC (Music Player Client) are installed and configured.
 # It will automatically search for duplicates and remove them.
 
+set -e
+
+display_help() {
+    cat <<HELP
+Usage: $(basename "$0") [OPTIONS]
+
+Scans the current MPD queue and removes duplicate entries (matched by file
+path), repeating until none remain. Operates directly on the in-memory
+queue -- no playlist file is read or written.
+
+Options:
+  -h, --help  Show this help message.
+HELP
+    exit 0
+}
+
+case "${1:-}" in
+    -h|--help) display_help ;;
+    "") ;;
+    *)
+        echo "Unknown option: $1" >&2
+        display_help
+        ;;
+esac
+
 # Function: mpd_first_duplicate
-# Purpose: This function searches the playlist for the first duplicate entry based on the file name.
+# Purpose: This function searches the playlist for the first duplicate entry based on the file path.
 # Input: None
-# Output: Position of the first duplicate item or empty if no duplicates are found.
+# Output: Position of the first duplicate item on stdout, or nothing if none are found.
 mpd_first_duplicate(){
   # Check if the playlist is empty by using 'mpc playlist' and searching for any output
   if ! mpc playlist | grep -q .; then
-    echo "Playlist is empty."  # Inform the user if the playlist has no items
+    # stderr, not stdout: the caller captures this function's stdout as the
+    # duplicate position, and would otherwise treat this message itself as
+    # one, looping forever trying to "mpc del" it.
+    echo "Playlist is empty." >&2
     return  # Exit the function if the playlist is empty
   fi
 
   # List the playlist with position and file path, then process it with awk
-  # - Position is stored in 'pos', and file name is used to track duplicates.
+  # - Position is stored in 'pos', and file path is used to track duplicates.
   # - When a file appears more than once, its position is printed and the function exits.
   mpc -f "%position% \t %file%" playlist | awk '{
     pos=$1          # Store the position of the current song
@@ -46,13 +76,13 @@ mpd_delete_duplicates(){
   while true; do
     # Get the position of the first duplicate
     item="$(mpd_first_duplicate)"
-    
+
     # Exit the loop if no duplicate is found (empty result)
     if [ -z "$item" ]; then
       echo "No more duplicates found."  # Inform the user when no duplicates remain
       break  # Exit the loop when no more duplicates are found
     fi
-    
+
     # Log and delete the duplicate item at the given position
     echo "Deleting duplicate at position $item..."  # Provide feedback on deletion
     mpc del "$item"  # Remove the song from the playlist using mpc
@@ -61,4 +91,3 @@ mpd_delete_duplicates(){
 
 # Call the function to delete duplicates from the playlist
 mpd_delete_duplicates
-


### PR DESCRIPTION
## Summary
- `mpd-remove-duplicates-queue.sh`: fixes an infinite loop against an empty/unreachable queue — the "Playlist is empty." message was written to stdout, where the caller captured it as if it were a duplicate position and kept retrying `mpc del` on it forever. Moved to stderr, added `set -e`, added `-h`/`--help`.
- `mpd-deduplicate-save-and-reload.sh`: moved `PLAYLIST_DIR`/`PLAYLIST_NAME` out of the hardcoded script into a gitignored `~/.config/mpd-find-dup/mpd-deduplicate-save-and-reload.conf`, seeded from a tracked `.conf.example`, matching every other script in this repo. Added a placeholder-value guard, `set -e`, and documented that `PLAYLIST_DIR` must match MPD's own `playlist_directory` (previously undocumented — `mpc save`/`load`/`rm` use MPD's own config independent of this variable). Added `-h`/`--help`.
- Updated `mpd-find-dup/README.md` to match.

## Test plan
- [x] `bash -n` passes for both scripts
- [x] `-h` works for both scripts
- [x] Unreachable/empty queue no longer infinite-loops in `mpd-remove-duplicates-queue.sh` — reports "No more duplicates found." instead
- [x] First run of `mpd-deduplicate-save-and-reload.sh` seeds the config and exits with instructions; rejects the placeholder `PLAYLIST_DIR`; proceeds normally once a real value is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)