### PR TITLE
Add rm-duplicates-playlist: fix broken long flags, hardcoded config

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Collection of scripts related to mpd & mpc.
 | **[mpd-find-dup](./mpd-find-dup/)** | Contains two scripts for deduplicating MPD queues: `mpd-remove-duplicates-queue.sh` interactively deletes duplicates from the current MPD playlist in-place, while `mpd-deduplicate-save-and-reload.sh` saves the current queue as a playlist, removes duplicates, then reloads the cleaned playlist. |
 | **[mpd_rewind_daemon](./mpd_rewind_daemon/)** | A background daemon for MPD that automatically rewinds playback by a few seconds when resuming from pause, improving the experience for music, mixes, podcasts, and audiobooks. |
 | **[mpdsimilar](./mpdsimilar/)** | Fetches similar artist tracks from Last.fm for the currently playing track or every track in the queue, and adds a sample of them to the MPD queue. |
+| **[rm-duplicates-playlist](./rm-duplicates-playlist/)** | Removes duplicate entries from a saved MPD playlist or the current queue, or lists available playlists, combining what the two `mpd-find-dup` scripts each do separately into one tool. |
 
 ### Prerequisites
 Listed in each scripts README.md.

--- a/rm-duplicates-playlist/.gitignore
+++ b/rm-duplicates-playlist/.gitignore
@@ -1,0 +1,2 @@
+# Ignore a locally-created live config; only rm-duplicates-playlist.conf.example is tracked
+rm-duplicates-playlist.conf

--- a/rm-duplicates-playlist/README.md
+++ b/rm-duplicates-playlist/README.md
@@ -1,0 +1,62 @@
+# Playlist/Queue Duplicate Remover
+
+This script removes duplicate entries (matched by file path, case-insensitively) from a saved MPD playlist or from the current MPD queue, and can also list the playlists MPD knows about. It combines what the two [`mpd-find-dup`](../mpd-find-dup/) scripts each do separately into a single tool, and adds a `.bak` backup of the playlist before it's modified.
+
+## Features
+
+- **Playlist mode (`-p`)**: Deduplicates a named, already-saved MPD playlist in place.
+- **Queue mode (`-q`)**: Saves the current queue to a temporary playlist, deduplicates it, then clears and reloads the queue with the cleaned result and resumes playback.
+- **List mode (`-l`)**: Lists all playlists MPD knows about, so you can find the name to pass to `-p`.
+- Backs up the playlist file (`.bak`) before writing changes, and makes no changes at all if no duplicates are found.
+- Cleans up its temporary queue-mode playlist on exit, even on error.
+
+## Requirements
+
+- `mpc`
+- `awk`
+
+## Configuration
+
+Settings live in `~/.config/rm-duplicates-playlist/rm-duplicates-playlist.conf`, seeded automatically from [`rm-duplicates-playlist.conf.example`](./rm-duplicates-playlist.conf.example) the first time you run `-p` or `-q` (`-l` doesn't need it). Edit the copy in `~/.config/rm-duplicates-playlist/`, not the template.
+
+- `PLAYLIST_DIR`: directory where MPD playlists are stored. **Must match MPD's own `playlist_directory`** — `mpc save`/`load`/`rm` operate through MPD's own config, independent of this value, which is only used to read/write playlist files directly.
+
+The script won't run `-p`/`-q` until `PLAYLIST_DIR` has been changed from its placeholder value.
+
+## Usage
+
+```bash
+./rm-duplicates-playlist.sh [-v] (-p <playlist_name> | -q | -l)
+```
+
+- `-p`, `--playlist NAME`: Remove duplicates from the named playlist.
+- `-q`, `--queue`: Remove duplicates from the current MPD queue.
+- `-l`, `--list`: List all available MPD playlists and exit.
+- `-v`, `--verbose`: Enable verbose output.
+- `-h`, `--help`: Show usage and exit.
+
+Exactly one of `-p`, `-q`, or `-l` must be given.
+
+Example usage:
+
+```bash
+./rm-duplicates-playlist.sh -l
+./rm-duplicates-playlist.sh -v -p my_playlist
+./rm-duplicates-playlist.sh -q
+```
+
+## Example Output
+
+```bash
+Processing playlist: my_playlist
+Original playlist has 42 entries.
+Removed 3 duplicate(s).
+Updated playlist has 39 entries.
+Processing complete. Updated playlist saved as 'my_playlist'.
+```
+
+## License
+
+This project is licensed under the **GNU General Public License v3.0**.
+
+See [LICENSE](../LICENSE) for more information.

--- a/rm-duplicates-playlist/rm-duplicates-playlist.conf.example
+++ b/rm-duplicates-playlist/rm-duplicates-playlist.conf.example
@@ -1,0 +1,11 @@
+# rm-duplicates-playlist.conf
+#
+# Copied to ~/.config/rm-duplicates-playlist/rm-duplicates-playlist.conf on
+# first run if that file doesn't already exist. Edit the copy there, not
+# this template.
+
+# Directory where MPD playlists are stored. Must match MPD's own
+# playlist_directory -- mpc save/load/rm operate through MPD's own config,
+# independent of this value, which is only used to read/write playlist
+# files directly. No trailing slash.
+PLAYLIST_DIR="/path/to/your/mpd/playlists"

--- a/rm-duplicates-playlist/rm-duplicates-playlist.sh
+++ b/rm-duplicates-playlist/rm-duplicates-playlist.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/bash
+# Script Name: rm-duplicates-playlist.sh
+# Description: Removes duplicate entries from a playlist or the current MPD queue.
+#              Supports playlist mode (-p), queue mode (-q), and listing playlists (-l).
+#              Duplicates are detected by exact path match (case-insensitive).
+# Usage: ./rm-duplicates-playlist.sh [-v] (-p <playlist_name> | -q | -l)
+#   -v, --verbose    Enable verbose output
+#   -p, --playlist   Specify the playlist to process
+#   -q, --queue      Process the current MPD queue
+#   -l, --list       List all available playlists
+#   -h, --help       Show usage and exit
+#
+# Configuration:
+#   PLAYLIST_DIR lives in ~/.config/rm-duplicates-playlist/rm-duplicates-playlist.conf,
+#   seeded from rm-duplicates-playlist.conf.example (shipped alongside this
+#   script) on first run.
+# Version: 1.0
+
+set -e
+
+# Temporary playlist name for queue mode (without .m3u extension)
+TEMP_PLAYLIST="currentqueue"
+
+# Flags for script behavior
+VERBOSE=false
+QUEUE_MODE=false
+LIST_MODE=false
+PLAYLIST_NAME=""
+
+# Print a short error plus a pointer to --help, then exit 1. Used for
+# argument-validation errors (missing/conflicting flags) rather than -h.
+usage() {
+    echo "$1" >&2
+    echo "Try '$(basename "$0") --help' for usage." >&2
+    exit 1
+}
+
+display_help() {
+    cat <<HELP
+Usage: $(basename "$0") [-v] (-p <playlist_name> | -q | -l)
+
+Removes duplicate entries (matched by file path, case-insensitively) from
+a saved MPD playlist or the current queue.
+
+Options:
+  -p, --playlist NAME  Remove duplicates from the named playlist.
+  -q, --queue          Remove duplicates from the current MPD queue.
+  -l, --list           List all available MPD playlists and exit.
+  -v, --verbose        Enable verbose output.
+  -h, --help           Show this help message.
+
+Exactly one of -p, -q, or -l must be given.
+HELP
+    exit 0
+}
+
+# Function to clean up temporary files
+cleanup() {
+    if [[ -f "${PLAYLIST_DIR}/${TEMP_PLAYLIST}.m3u" ]]; then
+        [[ "$VERBOSE" == true ]] && echo "Cleaning up temporary playlist: ${PLAYLIST_DIR}/${TEMP_PLAYLIST}.m3u"
+        rm -f "${PLAYLIST_DIR}/${TEMP_PLAYLIST}.m3u"
+    fi
+    if [[ -f "${PLAYLIST_DIR}/${TEMP_PLAYLIST}.m3u.bak" ]]; then
+        [[ "$VERBOSE" == true ]] && echo "Cleaning up temporary backup: ${PLAYLIST_DIR}/${TEMP_PLAYLIST}.m3u.bak"
+        rm -f "${PLAYLIST_DIR}/${TEMP_PLAYLIST}.m3u.bak"
+    fi
+    # Remove the playlist from MPD's database if it exists
+    if mpc lsplaylists | grep -Fxq "$TEMP_PLAYLIST"; then
+        [[ "$VERBOSE" == true ]] && echo "Removing temporary playlist from MPD database: $TEMP_PLAYLIST"
+        mpc rm "$TEMP_PLAYLIST" > /dev/null
+    fi
+}
+
+# Trap to ensure cleanup runs on script exit
+trap cleanup EXIT
+
+# Parse command-line options (both short and long forms)
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -v|--verbose) VERBOSE=true; shift ;;
+        -q|--queue)   QUEUE_MODE=true; shift ;;
+        -l|--list)    LIST_MODE=true; shift ;;
+        -p|--playlist)
+            if [[ $# -lt 2 ]]; then
+                usage "Error: -p/--playlist requires an argument."
+            fi
+            PLAYLIST_NAME="$2"
+            shift 2
+            ;;
+        -h|--help) display_help ;;
+        *)
+            echo "Unknown option: $1" >&2
+            display_help
+            ;;
+    esac
+done
+
+# Ensure only one of -p, -q, or -l is specified
+if [[ "$LIST_MODE" == true && ("$QUEUE_MODE" == true || -n "$PLAYLIST_NAME") ]]; then
+    usage "Error: Cannot use -l with -p or -q."
+fi
+
+if [[ "$QUEUE_MODE" == true && -n "$PLAYLIST_NAME" ]]; then
+    usage "Error: Cannot use -q and -p together."
+fi
+
+if [[ "$QUEUE_MODE" == false && "$LIST_MODE" == false && -z "$PLAYLIST_NAME" ]]; then
+    usage "Error: Either -p, -q, or -l must be specified."
+fi
+
+# List mode: Display all available playlists and exit. Doesn't touch
+# PLAYLIST_DIR, so it works even before the config file has been set up.
+if [[ "$LIST_MODE" == true ]]; then
+    echo "Available playlists:"
+    mpc lsplaylists
+    exit 0
+fi
+
+# Config lives in ~/.config/rm-duplicates-playlist/rm-duplicates-playlist.conf,
+# seeded from the rm-duplicates-playlist.conf.example template shipped
+# alongside this script on first run. Only -p/-q need it.
+CONFIG_DIR="$HOME/.config/rm-duplicates-playlist"
+CONFIG_FILE="$CONFIG_DIR/rm-duplicates-playlist.conf"
+
+if [[ ! -f "$CONFIG_FILE" ]]; then
+    mkdir -p "$CONFIG_DIR"
+    cp "$(dirname "$0")/rm-duplicates-playlist.conf.example" "$CONFIG_FILE"
+    echo "Created $CONFIG_FILE -- edit it with your playlist directory, then run this again." >&2
+    exit 1
+fi
+
+# shellcheck source=rm-duplicates-playlist.conf.example
+source "$CONFIG_FILE"
+
+if [[ "$PLAYLIST_DIR" == "/path/to/your/mpd/playlists" ]]; then
+    echo "Error: $CONFIG_FILE still has a placeholder PLAYLIST_DIR value. Edit it first." >&2
+    exit 1
+fi
+
+# Queue mode: Save the current queue to a temporary playlist
+if [[ "$QUEUE_MODE" == true ]]; then
+    # Delete the temporary playlist if it already exists
+    if mpc lsplaylists | grep -Fxq "$TEMP_PLAYLIST"; then
+        [[ "$VERBOSE" == true ]] && echo "Deleting existing temporary playlist: $TEMP_PLAYLIST"
+        mpc rm "$TEMP_PLAYLIST" > /dev/null
+    fi
+
+    [[ "$VERBOSE" == true ]] && echo "Saving current MPD queue to $TEMP_PLAYLIST..."
+    mpc save "$TEMP_PLAYLIST" > /dev/null  # mpc appends .m3u automatically
+    PLAYLIST_NAME="$TEMP_PLAYLIST"
+fi
+
+# Full path to the playlist file
+PLAYLIST_PATH="${PLAYLIST_DIR}/${PLAYLIST_NAME}.m3u"
+
+# Validate that the playlist file exists
+if [[ ! -f "$PLAYLIST_PATH" ]]; then
+    echo "Error: Playlist '$PLAYLIST_NAME' not found!" >&2
+    exit 1
+fi
+
+ORIGINAL_COUNT=$(wc -l < "$PLAYLIST_PATH")
+
+# Use awk-based seen-tracking to detect duplicates preserving order
+DEDUPED=$(awk '!seen[tolower($0)]++' "$PLAYLIST_PATH")
+
+# $DEDUPED being empty means zero entries, not one blank line -- `wc -l`
+# on an empty string via `echo`/here-string would otherwise report 1.
+if [[ -z "$DEDUPED" ]]; then
+    DEDUPED_COUNT=0
+else
+    DEDUPED_COUNT=$(wc -l <<< "$DEDUPED")
+fi
+
+if [[ "$ORIGINAL_COUNT" -eq "$DEDUPED_COUNT" ]]; then
+    echo "No duplicate entries found in the playlist. No changes made."
+
+    if [[ "$QUEUE_MODE" == true ]]; then
+        echo "Skipping queue processing to prevent clearing MPD queue."
+    fi
+
+    exit 0
+fi
+
+# Backup the playlist before making changes
+cp "$PLAYLIST_PATH" "${PLAYLIST_PATH}.bak"
+
+# Verbose output: Display original playlist info
+if [[ "$VERBOSE" == true ]]; then
+    echo "Processing playlist: $PLAYLIST_NAME"
+    echo "Original playlist has $ORIGINAL_COUNT entries."
+fi
+
+# Write deduplicated entries back to the playlist file
+echo "$DEDUPED" > "$PLAYLIST_PATH"
+
+# Verbose output: Report removed duplicates
+if [[ "$VERBOSE" == true ]]; then
+    REMOVED_COUNT=$(( ORIGINAL_COUNT - DEDUPED_COUNT ))
+    echo "Removed $REMOVED_COUNT duplicate(s)."
+    echo "Updated playlist has $DEDUPED_COUNT entries."
+fi
+
+# Queue mode: Reload the MPD queue with the deduplicated playlist
+if [[ "$QUEUE_MODE" == true ]]; then
+    [[ "$VERBOSE" == true ]] && echo "Clearing current MPD queue..."
+    mpc clear > /dev/null
+
+    [[ "$VERBOSE" == true ]] && echo "Loading deduplicated playlist into MPD queue..."
+    mpc load "$TEMP_PLAYLIST" > /dev/null
+
+    [[ "$VERBOSE" == true ]] && echo "Starting playback..."
+    mpc play > /dev/null
+fi
+
+# Final confirmation message
+echo "Processing complete. Updated playlist saved as '$PLAYLIST_NAME'."


### PR DESCRIPTION
## Summary
- Brings the previously-untracked `rm-duplicates-playlist.sh` into the repo. It combines what the two `mpd-find-dup` scripts each do separately (queue mode, playlist mode) into one tool, plus a `-l`/list-playlists mode and a `.bak` backup before writing changes.
- Fixes a real bug: its own `--help`/usage text advertised `--verbose`/`--playlist`/`--queue`/`--list`, but argument parsing used `getopts`, which only understands short options — every long flag was silently rejected. Replaced with a manual `while`/`case` loop (as used elsewhere in this repo), so the documented long forms actually work. Added `-h`/`--help`.
- Moved `PLAYLIST_DIR` out of a hardcoded personal absolute path baked into the tracked script into a gitignored `~/.config/rm-duplicates-playlist/rm-duplicates-playlist.conf`, seeded from a tracked `.conf.example`, with a placeholder guard — matching every other script in this repo. `-l`/`-h` don't require it.
- Fixed a dedup-count edge case: `wc -l` on the empty `$DEDUPED` string via a here-string reports `1`, not `0`, so an already-duplicate-free empty playlist was treated as having a duplicate and got a spurious blank line written into it.
- Added `set -e`, a `README.md`, and a row in the main `README.md` table; removed an unused `UNIQUE_COUNT` calculation.

## Test plan
- [x] `bash -n` passes
- [x] `-h`/`--help` work; previously-broken long flags (e.g. `--queue`) are now recognized
- [x] `-l` works without requiring the config file
- [x] First `-p`/`-q` run seeds the config and exits with instructions; rejects the placeholder `PLAYLIST_DIR`
- [x] End-to-end dedup test: duplicate (case-insensitive) entries removed, `.bak` backup created, re-run against an already-deduped playlist is a correct no-op
- [x] Empty-playlist edge case no longer inserts a spurious blank line

🤖 Generated with [Claude Code](https://claude.com/claude-code)