### PR TITLE
mpd-notifier: broader cover art search, embedded art, grayscale, categories

### DIFF
--- a/mpd-notifier/README.md
+++ b/mpd-notifier/README.md
@@ -1,16 +1,19 @@
 # mpd-scripts - mpd-notifier
 - Uses mpd, mpc, bash and notify-send to provide desktop notifications with ARTST, TITLE, and ALBUMART.
-- Takes into account, albums where the album art cover.jpg file might be missing and provides a generic eight-note image.
+- Looks for a cover/folder/artwork/front image in the track's directory (not just a literal cover.jpg), optionally falls back to art embedded in the track's own tags (`embed_art_fallback`), and finally falls back to a generic eight-note image if neither is found.
 - Will notify user if mpd is currently stopped. 
-- Will show the artist, title, albumart with (paused) appended at the end when mpd is paused.  
+- Will show the artist, title, albumart with (paused) appended at the end when mpd is paused, and optionally shows the cover art in grayscale while paused (`grayscale_when_paused`).
 - On compilations, shows the track's real artist instead of the album artist (e.g. "Various Artists").
 - Each notification replaces the previous one instead of stacking, so repeated updates (e.g. from the watch script below) don't pile up.
+- Can tag notifications with a category (`notify_categories`) so a notification daemon can filter or style them by playback state.
 
 ## Requirements
 
 - `mpc`
 - `notify-send` (`libnotify-bin`)
 - `dunst` (optional — only needed for `use_dunstify`)
+- `ffmpeg` (optional — only needed for `embed_art_fallback`)
+- `imagemagick` (optional — only needed for `grayscale_when_paused`)
 
 ## Installation
 
@@ -56,6 +59,9 @@ Settings live in `~/.config/mpd-notifier/mpd-notifier.conf`, seeded automaticall
 - `cache_dir`: where the fallback image and copied cover art are cached.
 - `enable_actions`: set to `"true"` to add Play-Pause/Next buttons to the notification, plus Previous unless MPD's `consume` mode is on (in which case there's no previous track left in the queue to go back to). Off by default since it requires a notify-send that supports `-A`/`--action` (e.g. `libnotify-bin`) — not every provider does. When it isn't supported, this is detected automatically and the buttons are silently skipped. Note that whether actions actually render as clickable buttons also depends on your notification *daemon* (e.g. dunst, not just the `notify-send`/`dunstify` client) actually being the active one handling notifications.
 - `use_dunstify`: set to `"true"` to send notifications via [dunst](https://github.com/dunst-project/dunst)'s `dunstify` instead of `notify-send` (install with e.g. `sudo apt install dunst`). Worth enabling if your system's stock notify-send is missing `-r`/`--replace-id` or `-A`/`--action` support — notably Ubuntu 22.04's `libnotify-bin`, which ships one version behind the release that added them. Default: `"false"`.
+- `embed_art_fallback`: set to `"true"` to try extracting album art embedded in the track's own tags via `ffmpeg` (`sudo apt install ffmpeg`) when no cover/folder/artwork/front image file is found in the track's directory. Default: `"false"`.
+- `grayscale_when_paused`: set to `"true"` to show a grayscale version of the cover art while paused, as a visual cue in addition to the "(paused)" text. Requires ImageMagick's `convert` (`sudo apt install imagemagick`). Default: `"false"`.
+- `notify_categories`: set to `"true"` to tag notifications with a category (`mpd`/`mpd-paused`/`mpd-stopped`) via `-c`/`--category`, letting a notification daemon filter or style them by playback state. Only applied if the notify-send/dunstify in use advertises support (detected automatically). Default: `"false"`.
 
 ## License
 

--- a/mpd-notifier/README.md
+++ b/mpd-notifier/README.md
@@ -63,6 +63,22 @@ Settings live in `~/.config/mpd-notifier/mpd-notifier.conf`, seeded automaticall
 - `grayscale_when_paused`: set to `"true"` to show a grayscale version of the cover art while paused, as a visual cue in addition to the "(paused)" text. Requires ImageMagick's `convert` (`sudo apt install imagemagick`). Default: `"false"`.
 - `notify_categories`: set to `"true"` to tag notifications with a category (`mpd`/`mpd-paused`/`mpd-stopped`) via `-c`/`--category`, letting a notification daemon filter or style them by playback state. Only applied if the notify-send/dunstify in use advertises support (detected automatically). Default: `"false"`.
 
+  Example dunst rules (`~/.config/dunst/dunstrc`) using all three categories:
+
+  ```ini
+  [mpd]
+      category = "mpd"
+
+  [mpd-paused]
+      category = "mpd-paused"
+      background = "#333333"
+      timeout = 0
+
+  [mpd-stopped]
+      category = "mpd-stopped"
+      timeout = 3000
+  ```
+
 ## License
 
 This project is licensed under the **GNU General Public License v3.0**.

--- a/mpd-notifier/mpd-notifier.conf.example
+++ b/mpd-notifier/mpd-notifier.conf.example
@@ -3,7 +3,7 @@
 # Copied to ~/.config/mpd-notifier/mpd-notifier.conf on first run if that
 # file doesn't already exist. Edit the copy there, not this template.
 
-# Local music library path, used to look up cover.jpg next to the playing
+# Local music library path, used to look up cover art next to the playing
 # track. Only used when MPD_HOST is empty (see below).
 dir="$HOME/Music/"
 
@@ -28,3 +28,20 @@ enable_actions="false"
 # (e.g. Ubuntu 22.04's libnotify-bin, which is one version behind that);
 # install dunst first (e.g. `sudo apt install dunst`). Default: "false".
 use_dunstify="false"
+
+# When no cover/folder/artwork/front image is found in the track's
+# directory, try to extract album art embedded in the track's own tags via
+# ffmpeg instead of going straight to the fallback image. Requires ffmpeg
+# (e.g. `sudo apt install ffmpeg`). Set to "true" to enable. Default: "false".
+embed_art_fallback="false"
+
+# Show a grayscale version of the cover art while paused, as a visual cue in
+# addition to the "(paused)" text. Requires ImageMagick's `convert` (e.g.
+# `sudo apt install imagemagick`). Set to "true" to enable. Default: "false".
+grayscale_when_paused="false"
+
+# Tag notifications with a category ("mpd"/"mpd-paused"/"mpd-stopped") via
+# -c/--category, letting a notification daemon filter or style them by
+# playback state. Only applied if the notify-send/dunstify in use advertises
+# support. Set to "true" to enable. Default: "false".
+notify_categories="false"

--- a/mpd-notifier/mpd-notifier.sh
+++ b/mpd-notifier/mpd-notifier.sh
@@ -4,7 +4,12 @@
 # use_dunstify="true") for the currently playing MPD track, showing title,
 # artist, and album, using the mpc command-line tool. On compilations, shows
 # the track's real artist rather than the album's artist (e.g. "Various
-# Artists"). Falls back to a generic image when no cover art is found.
+# Artists"). Looks for a cover/folder/artwork/front image in the track's
+# directory, optionally falls back to art embedded in the file itself (see
+# embed_art_fallback), and falls back further to a generic image when none
+# is found. See mpd-notifier.conf.example for optional features: embedded
+# art extraction, grayscale cover art while paused, and notification
+# categories.
 
 # Cobbled together from other now playing scripts.
 # Image found on Google Images
@@ -49,12 +54,13 @@ for cmd in mpc "$NOTIFY_CMD"; do
 done
 
 if [ "$NOTIFY_CMD" == "dunstify" ]; then
-    # dunstify reliably supports both, regardless of exact --help wording.
+    # dunstify reliably supports all of these, regardless of exact --help wording.
     NOTIFY_REPLACE_ARGS=(-r 91325)
     NOTIFY_ACTIONS_SUPPORTED=1
+    NOTIFY_CATEGORY_SUPPORTED=1
 else
-    # Not every notify-send provider supports -r/--replace-id or
-    # -A/--action (e.g. the notify-send.sh reimplementation, or Ubuntu
+    # Not every notify-send provider supports -r/--replace-id, -A/--action,
+    # or -c/--category (e.g. the notify-send.sh reimplementation, or Ubuntu
     # 22.04's stock libnotify-bin), so only use them if advertised.
     NOTIFY_SEND_HELP="$("$NOTIFY_CMD" --help 2>/dev/null)"
 
@@ -66,6 +72,11 @@ else
     NOTIFY_ACTIONS_SUPPORTED=0
     if echo "$NOTIFY_SEND_HELP" | grep -q -- '--action'; then
         NOTIFY_ACTIONS_SUPPORTED=1
+    fi
+
+    NOTIFY_CATEGORY_SUPPORTED=0
+    if echo "$NOTIFY_SEND_HELP" | grep -q -- '--category'; then
+        NOTIFY_CATEGORY_SUPPORTED=1
     fi
 fi
 
@@ -102,11 +113,32 @@ finish_song_info() {
     fi
 
     if [ -z "${MPD_HOST}" ]; then
-        local_image="$(dirname "$dir${array[5]}")/cover.jpg"
+        track_path="$dir${array[5]}"
+        track_dir="$(dirname "$track_path")"
         cache_image="$cache_dir/cover.jpg"
-        # Check if cover.jpg exists locally, if not, use the fallback image directly
-        if [ -f "$local_image" ]; then
+
+        # Look for a cover image file in the track's directory -- any
+        # filename containing "cover", "folder", "artwork", or "front"
+        # (case-insensitive), not just a literal cover.jpg. Uses -iname
+        # (basename-only matching) rather than -iregex, which matches the
+        # whole path -- an artist/album directory containing one of these
+        # words (e.g. "Front Line Assembly") would otherwise make every
+        # .jpg/.jpeg in that directory match.
+        local_image=""
+        if [ -d "$track_dir" ]; then
+            local_image="$(find "$track_dir" -maxdepth 1 -type f \
+                \( -iname '*cover*.jpg' -o -iname '*cover*.jpeg' \
+                   -o -iname '*folder*.jpg' -o -iname '*folder*.jpeg' \
+                   -o -iname '*artwork*.jpg' -o -iname '*artwork*.jpeg' \
+                   -o -iname '*front*.jpg' -o -iname '*front*.jpeg' \) \
+                2>/dev/null | sort | head -n1)"
+        fi
+
+        if [ -n "$local_image" ] && [ -f "$local_image" ]; then
             cp "$local_image" "$cache_image"
+        elif [ "${embed_art_fallback}" == "true" ] && command -v ffmpeg &>/dev/null \
+             && ffmpeg -loglevel quiet -y -i "$track_path" "$cache_image" </dev/null 2>/dev/null; then
+            : # No cover file found, but ffmpeg pulled embedded art out of the track itself.
         else
             cache_image="$fallback_image"
         fi
@@ -217,6 +249,18 @@ send_notification() {
     local summary="$1" body="$2" image="$3"
     local args=("${NOTIFY_REPLACE_ARGS[@]}" -t "$notify_duration" -i "$image")
 
+    # With notify_categories="true" (and only if $NOTIFY_CMD advertises
+    # support), tag the notification "mpd"/"mpd-paused"/"mpd-stopped" so a
+    # notification daemon can filter or style it per playback state.
+    if [ "${notify_categories}" == "true" ] && [ "$NOTIFY_CATEGORY_SUPPORTED" -eq 1 ]; then
+        local category="mpd"
+        case "$status" in
+            paused)  category="mpd-paused" ;;
+            stopped) category="mpd-stopped" ;;
+        esac
+        args+=(-c "$category")
+    fi
+
     if [ "${enable_actions}" == "true" ] && [ "$NOTIFY_ACTIONS_SUPPORTED" -eq 1 ]; then
         local playpause_label="Pause"
         if [ "$status" == "paused" ]; then
@@ -240,6 +284,18 @@ if [ -f "$cache_image" ]; then
     image="$cache_image"
 else
     image="$fallback_image"
+fi
+
+# With grayscale_when_paused="true", show a grayscale cover while paused, as
+# a visual cue distinct from the "(paused)" text. Always written to a
+# separate scratch file rather than converted in place, since $image may be
+# $fallback_image -- a persistent cached file that must stay in color for
+# the next "playing" notification.
+if [ "$status" == "paused" ] && [ "${grayscale_when_paused}" == "true" ] && command -v convert &>/dev/null; then
+    paused_image="$cache_dir/paused-cover.jpg"
+    if convert "$image" -colorspace Gray "$paused_image" 2>/dev/null; then
+        image="$paused_image"
+    fi
 fi
 
 if [ "$status" == "playing" ]; then


### PR DESCRIPTION
## Summary
Ports capabilities from the untracked `mpd-not/mpd-notify.sh` into `mpd-notifier.sh`:

- **Broader cover art search (always on)**: matches any file containing "cover", "folder", "artwork", or "front" (case-insensitive) in the track's directory, not just a literal `cover.jpg`. Uses `-iname` (basename-only matching) rather than `-iregex`, which matches the whole path — an artist/album directory containing one of those words (e.g. "Front Line Assembly") would otherwise make every `.jpg` in that directory match.
- **`embed_art_fallback="true"`**: when no cover file is found, try extracting album art embedded in the track's own tags via `ffmpeg` before falling back to the generic image.
- **`grayscale_when_paused="true"`**: show a grayscale cover while paused (ImageMagick's `convert`), as a visual cue alongside the existing "(paused)" text. Written to a separate scratch file so the persistent cached cover/fallback image is never mutated in place.
- **`notify_categories="true"`**: tag notifications with a category (`mpd`/`mpd-paused`/`mpd-stopped`) via `-c`/`--category`, so a notification daemon (e.g. dunst) can filter or style them by playback state. Only applied if the notify-send/dunstify in use advertises support, detected the same way `-r`/`--replace-id` and `-A`/`--action` already are.

All three new behaviors default to `"false"` and require no new dependency unless explicitly enabled. `README.md` and `mpd-notifier.conf.example` updated accordingly.

## Test plan
- [x] `bash -n` passes
- [x] Cover-search glob verified against sample filenames/directories, including the "directory name contains a keyword" false-positive case (fixed via `-iname` instead of `-iregex`)
- [x] `ffmpeg` embedded-art extraction verified against a real audio file with embedded art
- [x] Grayscale `convert` verified to write to a separate file without mutating the source

🤖 Generated with [Claude Code](https://claude.com/claude-code)