### PR TITLE
Add rm-artists-playlist: fix silent full-playlist wipe, broken long flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Collection of scripts related to mpd & mpc.
 | **[mpd_rewind_daemon](./mpd_rewind_daemon/)** | A background daemon for MPD that automatically rewinds playback by a few seconds when resuming from pause, improving the experience for music, mixes, podcasts, and audiobooks. |
 | **[mpdsimilar](./mpdsimilar/)** | Fetches similar artist tracks from Last.fm for the currently playing track or every track in the queue, and adds a sample of them to the MPD queue. |
 | **[rm-duplicates-playlist](./rm-duplicates-playlist/)** | Removes duplicate entries from a saved MPD playlist or the current queue, or lists available playlists, combining what the two `mpd-find-dup` scripts each do separately into one tool. |
+| **[rm-artists-playlist](./rm-artists-playlist/)** | Removes songs by a list of artists from a saved MPD playlist or the current queue, or lists available playlists. |
 
 ### Prerequisites
 Listed in each scripts README.md.

--- a/rm-artists-playlist/.gitignore
+++ b/rm-artists-playlist/.gitignore
@@ -1,0 +1,2 @@
+# Ignore a locally-created live config; only rm-artists-playlist.conf.example is tracked
+rm-artists-playlist.conf

--- a/rm-artists-playlist/README.md
+++ b/rm-artists-playlist/README.md
@@ -1,0 +1,70 @@
+# Artist Remover
+
+This script removes songs by a list of artists from a saved MPD playlist or from the current MPD queue, and can also list the playlists MPD knows about. It's the artist-based counterpart to [`rm-duplicates-playlist`](../rm-duplicates-playlist/), sharing the same playlist/queue/list mode design.
+
+## Features
+
+- **Playlist mode (`-p`)**: Removes the listed artists' songs from a named, already-saved MPD playlist in place.
+- **Queue mode (`-q`)**: Saves the current queue to a temporary playlist, removes the listed artists' songs, then clears and reloads the queue with the result and resumes playback.
+- **List mode (`-l`)**: Lists all playlists MPD knows about, so you can find the name to pass to `-p`.
+- Backs up the playlist file (`.bak`) before writing changes, and makes no changes at all if none of the listed artists appear in the playlist.
+- Cleans up its temporary queue-mode playlist on exit, even on error.
+
+## Requirements
+
+- `mpc`
+
+## Matching behavior (read this before using it)
+
+Artist matching is an **unanchored, case-insensitive substring match** against each playlist entry's full file path, not an exact artist-tag match. A saved `.m3u` is just a flat list of file paths — once a playlist is on disk, there's no separate artist/album/title field left to match against, only the path string.
+
+This means: **use full, specific artist names in your artist file.** A short or common name (e.g. `Air`) can match unrelated paths that merely contain that substring somewhere — another artist, an album title, even a track title (e.g. `Fair Warning`, `Air Supply`, `Repair Man`). This script does not attempt to anchor matches to a particular path segment, so the responsibility for precise names is on the artist list you provide.
+
+**Blank lines in the artist file are ignored** (skipped before the match pattern is built). This matters: without that filtering, a blank line would produce an empty alternative in the underlying regex, which matches *every line* — silently removing the entire playlist or queue instead of just the named artists' songs.
+
+## Configuration
+
+Settings live in `~/.config/rm-artists-playlist/rm-artists-playlist.conf`, seeded automatically from [`rm-artists-playlist.conf.example`](./rm-artists-playlist.conf.example) the first time you run `-p` or `-q` (`-l` doesn't need it). Edit the copy in `~/.config/rm-artists-playlist/`, not the template.
+
+- `PLAYLIST_DIR`: directory where MPD playlists are stored. **Must match MPD's own `playlist_directory`** — `mpc save`/`load`/`rm` operate through MPD's own config, independent of this value, which is only used to read/write playlist files directly.
+- `ARTIST_FILE`: plain text file listing one artist name per line, to remove.
+
+The script won't run `-p`/`-q` until both have been changed from their placeholder values.
+
+## Usage
+
+```bash
+./rm-artists-playlist.sh [-v] (-p <playlist_name> | -q | -l)
+```
+
+- `-p`, `--playlist NAME`: Remove the listed artists' songs from the named playlist.
+- `-q`, `--queue`: Remove the listed artists' songs from the current MPD queue.
+- `-l`, `--list`: List all available MPD playlists and exit.
+- `-v`, `--verbose`: Enable verbose output.
+- `-h`, `--help`: Show usage and exit.
+
+Exactly one of `-p`, `-q`, or `-l` must be given.
+
+Example usage:
+
+```bash
+./rm-artists-playlist.sh -l
+./rm-artists-playlist.sh -v -p my_playlist
+./rm-artists-playlist.sh -q
+```
+
+## Example Output
+
+```bash
+Processing playlist: my_playlist
+Original playlist has 42 songs.
+Removed 5 songs.
+Updated playlist has 37 songs.
+Processing complete. Updated playlist saved as 'my_playlist'.
+```
+
+## License
+
+This project is licensed under the **GNU General Public License v3.0**.
+
+See [LICENSE](../LICENSE) for more information.

--- a/rm-artists-playlist/rm-artists-playlist.conf.example
+++ b/rm-artists-playlist/rm-artists-playlist.conf.example
@@ -1,0 +1,20 @@
+# rm-artists-playlist.conf
+#
+# Copied to ~/.config/rm-artists-playlist/rm-artists-playlist.conf on first
+# run if that file doesn't already exist. Edit the copy there, not this
+# template.
+
+# Directory where MPD playlists are stored. Must match MPD's own
+# playlist_directory -- mpc save/load/rm operate through MPD's own config,
+# independent of this value, which is only used to read/write playlist
+# files directly. No trailing slash.
+PLAYLIST_DIR="/path/to/your/mpd/playlists"
+
+# Plain text file listing one artist name per line, to remove from a
+# playlist or the current queue. Matching is an unanchored,
+# case-insensitive substring match against each playlist entry's full file
+# path (a saved .m3u is just a flat list of paths, with no separate
+# artist/album/title fields) -- use full, specific artist names, since a
+# short or common name (e.g. "Air") could match unrelated paths that
+# merely contain that substring. Blank lines in this file are ignored.
+ARTIST_FILE="/path/to/your/artists_to_remove.txt"

--- a/rm-artists-playlist/rm-artists-playlist.sh
+++ b/rm-artists-playlist/rm-artists-playlist.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/bash
+# Script Name: rm-artists-playlist.sh
+# Description: Removes songs from a playlist or the current MPD queue based on a list of artists.
+#              Supports playlist mode (-p), queue mode (-q), and listing playlists (-l).
+#              Matching is an unanchored, case-insensitive substring match against each
+#              playlist entry's full file path (a saved .m3u is just a flat list of paths,
+#              with no separate artist/album/title fields) -- use full, specific artist
+#              names in ARTIST_FILE, since a short or common name (e.g. "Air") could match
+#              unrelated paths that merely contain that substring.
+# Usage: ./rm-artists-playlist.sh [-v] (-p <playlist_name> | -q | -l)
+#   -v, --verbose    Enable verbose output
+#   -p, --playlist   Specify the playlist to process
+#   -q, --queue      Process the current MPD queue
+#   -l, --list       List all available playlists
+#   -h, --help       Show usage and exit
+#
+# Configuration:
+#   PLAYLIST_DIR and ARTIST_FILE live in
+#   ~/.config/rm-artists-playlist/rm-artists-playlist.conf, seeded from
+#   rm-artists-playlist.conf.example (shipped alongside this script) on
+#   first run.
+# Version: 1.8
+
+set -e
+
+# Temporary playlist name for queue mode (without .m3u extension)
+TEMP_PLAYLIST="currentqueue"
+
+# Flags for script behavior
+VERBOSE=false
+QUEUE_MODE=false
+LIST_MODE=false
+PLAYLIST_NAME=""
+
+# Print a short error plus a pointer to --help, then exit 1. Used for
+# argument-validation errors (missing/conflicting flags) rather than -h.
+usage() {
+    echo "$1" >&2
+    echo "Try '$(basename "$0") --help' for usage." >&2
+    exit 1
+}
+
+display_help() {
+    cat <<HELP
+Usage: $(basename "$0") [-v] (-p <playlist_name> | -q | -l)
+
+Removes songs by a list of artists (read from ARTIST_FILE, one per line)
+from a saved MPD playlist or the current queue. Matching is an unanchored,
+case-insensitive substring match against each entry's full file path -- use
+full, specific artist names, since a short or common name could match
+unrelated paths that merely contain that substring. Blank lines in
+ARTIST_FILE are ignored.
+
+Options:
+  -p, --playlist NAME  Remove the listed artists' songs from the named playlist.
+  -q, --queue          Remove the listed artists' songs from the current MPD queue.
+  -l, --list           List all available MPD playlists and exit.
+  -v, --verbose        Enable verbose output.
+  -h, --help           Show this help message.
+
+Exactly one of -p, -q, or -l must be given.
+HELP
+    exit 0
+}
+
+# Function to clean up temporary files
+cleanup() {
+    if [[ -f "${PLAYLIST_DIR}/${TEMP_PLAYLIST}.m3u" ]]; then
+        [[ "$VERBOSE" == true ]] && echo "Cleaning up temporary playlist: ${PLAYLIST_DIR}/${TEMP_PLAYLIST}.m3u"
+        rm -f "${PLAYLIST_DIR}/${TEMP_PLAYLIST}.m3u"
+    fi
+    if [[ -f "${PLAYLIST_DIR}/${TEMP_PLAYLIST}.m3u.bak" ]]; then
+        [[ "$VERBOSE" == true ]] && echo "Cleaning up temporary backup: ${PLAYLIST_DIR}/${TEMP_PLAYLIST}.m3u.bak"
+        rm -f "${PLAYLIST_DIR}/${TEMP_PLAYLIST}.m3u.bak"
+    fi
+    # Remove the playlist from MPD's database if it exists
+    if mpc lsplaylists | grep -Fxq "$TEMP_PLAYLIST"; then
+        [[ "$VERBOSE" == true ]] && echo "Removing temporary playlist from MPD database: $TEMP_PLAYLIST"
+        mpc rm "$TEMP_PLAYLIST" > /dev/null
+    fi
+}
+
+# Trap to ensure cleanup runs on script exit
+trap cleanup EXIT
+
+# Parse command-line options (both short and long forms)
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -v|--verbose) VERBOSE=true; shift ;;
+        -q|--queue)   QUEUE_MODE=true; shift ;;
+        -l|--list)    LIST_MODE=true; shift ;;
+        -p|--playlist)
+            if [[ $# -lt 2 ]]; then
+                usage "Error: -p/--playlist requires an argument."
+            fi
+            PLAYLIST_NAME="$2"
+            shift 2
+            ;;
+        -h|--help) display_help ;;
+        *)
+            echo "Unknown option: $1" >&2
+            display_help
+            ;;
+    esac
+done
+
+# Ensure only one of -p, -q, or -l is specified
+if [[ "$LIST_MODE" == true && ("$QUEUE_MODE" == true || -n "$PLAYLIST_NAME") ]]; then
+    usage "Error: Cannot use -l with -p or -q."
+fi
+
+if [[ "$QUEUE_MODE" == true && -n "$PLAYLIST_NAME" ]]; then
+    usage "Error: Cannot use -q and -p together."
+fi
+
+if [[ "$QUEUE_MODE" == false && "$LIST_MODE" == false && -z "$PLAYLIST_NAME" ]]; then
+    usage "Error: Either -p, -q, or -l must be specified."
+fi
+
+# List mode: Display all available playlists and exit. Doesn't touch
+# PLAYLIST_DIR/ARTIST_FILE, so it works even before the config file has
+# been set up.
+if [[ "$LIST_MODE" == true ]]; then
+    echo "Available playlists:"
+    mpc lsplaylists
+    exit 0
+fi
+
+# Config lives in ~/.config/rm-artists-playlist/rm-artists-playlist.conf,
+# seeded from the rm-artists-playlist.conf.example template shipped
+# alongside this script on first run. Only -p/-q need it.
+CONFIG_DIR="$HOME/.config/rm-artists-playlist"
+CONFIG_FILE="$CONFIG_DIR/rm-artists-playlist.conf"
+
+if [[ ! -f "$CONFIG_FILE" ]]; then
+    mkdir -p "$CONFIG_DIR"
+    cp "$(dirname "$0")/rm-artists-playlist.conf.example" "$CONFIG_FILE"
+    echo "Created $CONFIG_FILE -- edit it with your playlist directory and artist file, then run this again." >&2
+    exit 1
+fi
+
+# shellcheck source=rm-artists-playlist.conf.example
+source "$CONFIG_FILE"
+
+if [[ "$PLAYLIST_DIR" == "/path/to/your/mpd/playlists" ]]; then
+    echo "Error: $CONFIG_FILE still has a placeholder PLAYLIST_DIR value. Edit it first." >&2
+    exit 1
+fi
+
+if [[ "$ARTIST_FILE" == "/path/to/your/artists_to_remove.txt" ]]; then
+    echo "Error: $CONFIG_FILE still has a placeholder ARTIST_FILE value. Edit it first." >&2
+    exit 1
+fi
+
+# Queue mode: Save the current queue to a temporary playlist
+if [[ "$QUEUE_MODE" == true ]]; then
+    # Delete the temporary playlist if it already exists
+    if mpc lsplaylists | grep -Fxq "$TEMP_PLAYLIST"; then
+        [[ "$VERBOSE" == true ]] && echo "Deleting existing temporary playlist: $TEMP_PLAYLIST"
+        mpc rm "$TEMP_PLAYLIST" > /dev/null
+    fi
+
+    [[ "$VERBOSE" == true ]] && echo "Saving current MPD queue to $TEMP_PLAYLIST..."
+    mpc save "$TEMP_PLAYLIST" > /dev/null  # mpc appends .m3u automatically
+    PLAYLIST_NAME="$TEMP_PLAYLIST"
+fi
+
+# Full path to the playlist file
+PLAYLIST_PATH="${PLAYLIST_DIR}/${PLAYLIST_NAME}.m3u"
+
+# Validate playlist and artist file
+if [[ ! -f "$PLAYLIST_PATH" ]]; then
+    echo "Error: Playlist '$PLAYLIST_NAME' not found!" >&2
+    exit 1
+fi
+
+if [[ ! -f "$ARTIST_FILE" ]]; then
+    echo "Error: Artist file '$ARTIST_FILE' not found!" >&2
+    exit 1
+fi
+
+# Check if the artist removal list is empty before proceeding
+if [[ ! -s "$ARTIST_FILE" ]]; then
+    echo "Artist removal list is empty. No changes made."
+
+    # If queue mode was enabled, we should not clear the queue accidentally
+    if [[ "$QUEUE_MODE" == true ]]; then
+        echo "Skipping queue processing to prevent clearing MPD queue."
+    fi
+
+    exit 0
+fi
+
+# Read artist names and create a grep pattern for matching. Blank lines are
+# dropped first -- an empty alternative in the resulting regex (e.g. from
+# "Artist One\n\nArtist Two") would otherwise match every line
+# unconditionally, silently wiping the *entire* playlist/queue instead of
+# just the named artists' songs. Remaining lines are escaped for regex
+# matching, then joined into a single alternation pattern.
+PATTERN=$(grep -v '^[[:space:]]*$' "$ARTIST_FILE" \
+    | sed -E 's/([]\/.^$*+?{}|()])/\\&/g' | tr '\n' '|' | sed 's/|$//')
+
+if [[ -z "$PATTERN" ]]; then
+    echo "Artist removal list is empty. No changes made."
+
+    if [[ "$QUEUE_MODE" == true ]]; then
+        echo "Skipping queue processing to prevent clearing MPD queue."
+    fi
+
+    exit 0
+fi
+
+# Check if any songs match the artist removal list
+if ! grep -iqE "$PATTERN" "${PLAYLIST_PATH}"; then
+    echo "No songs by the specified artists found in the playlist. No changes made."
+
+    # If queue mode was enabled, we should not clear the queue accidentally
+    if [[ "$QUEUE_MODE" == true ]]; then
+        echo "Skipping queue processing to prevent clearing MPD queue."
+    fi
+
+    exit 0
+fi
+
+# Backup the playlist before making changes
+cp "$PLAYLIST_PATH" "${PLAYLIST_PATH}.bak"
+
+# Verbose output: Display playlist info
+if [[ "$VERBOSE" == true ]]; then
+    echo "Processing playlist: $PLAYLIST_NAME"
+    echo "Original playlist has $(wc -l < "${PLAYLIST_PATH}.bak") songs."
+fi
+
+# Remove matching lines (songs by artists in the removal list)
+grep -iEv "$PATTERN" "${PLAYLIST_PATH}.bak" > "$PLAYLIST_PATH"
+
+# Verbose output: Display removed songs and updated playlist info
+if [[ "$VERBOSE" == true ]]; then
+    REMOVED_COUNT=$(($(wc -l < "${PLAYLIST_PATH}.bak") - $(wc -l < "$PLAYLIST_PATH")))
+    echo "Removed $REMOVED_COUNT songs."
+    echo "Updated playlist has $(wc -l < "$PLAYLIST_PATH") songs."
+fi
+
+# Queue mode: Update the MPD queue with the processed playlist
+if [[ "$QUEUE_MODE" == true ]]; then
+    [[ "$VERBOSE" == true ]] && echo "Clearing current MPD queue..."
+    mpc clear > /dev/null  # Clear the current queue
+
+    [[ "$VERBOSE" == true ]] && echo "Loading updated playlist into MPD queue..."
+    mpc load "$TEMP_PLAYLIST" > /dev/null  # Load the processed playlist into the queue
+
+    [[ "$VERBOSE" == true ]] && echo "Starting playback..."
+    mpc play > /dev/null  # Start playback
+fi
+
+# Final confirmation message
+echo "Processing complete. Updated playlist saved as '$PLAYLIST_NAME'."


### PR DESCRIPTION
## Summary
Brings the previously-untracked `rm-artists-playlist.sh` into the repo and fixes a critical data-loss bug plus the same issues found in its sibling `rm-duplicates-playlist.sh` (#58):

- **Critical**: the removal regex was built by joining escaped artist names with `|`. Any blank line in the artist file (in the middle, or a stray trailing one — trivial to introduce by hand) produced an empty alternative in that regex. Verified against real GNU grep: an empty alternative in `grep -E` matches every line unconditionally, so `grep -iEv` silently wiped the **entire playlist or queue** instead of just the named artists' songs, while the script still reported success. Fixed by dropping blank lines before building the pattern, with a matching "empty removal list" exit if nothing non-blank remains.
- Same broken long flags as `rm-duplicates-playlist.sh`: `--verbose`/`--playlist`/`--queue`/`--list` were documented but silently rejected by `getopts`. Replaced with the same manual `while`/`case` loop used elsewhere in this repo. Added `-h`/`--help`.
- `PLAYLIST_DIR` and `ARTIST_FILE` were both hardcoded to personal absolute paths baked into the tracked script, with no override at all for `ARTIST_FILE`. Moved both into a gitignored `~/.config/rm-artists-playlist/rm-artists-playlist.conf` seeded from a tracked `.conf.example`, with placeholder guards. `-l`/`-h` don't require it.
- Added `set -e`, a distinct "artist file not found" vs "empty" error, and a README documenting the unanchored-substring-match caveat (left as-is per discussion — the artist file is expected to use full, specific names). Added a row in the main `README.md` table.

## Test plan
- [x] `bash -n` passes
- [x] `-h`/`--help` work; previously-broken long flags (e.g. `--queue`) are now recognized
- [x] `-l` works without requiring the config file
- [x] First `-p`/`-q` run seeds the config and exits with instructions; rejects placeholder `PLAYLIST_DIR`/`ARTIST_FILE`
- [x] **Critical fix verified**: artist file with a blank line in the middle correctly removes only the targeted artists' tracks, not the whole playlist (confirmed against real GNU grep, which does match-everything on an empty regex alternative)
- [x] Artist file that is entirely blank lines is correctly treated as an empty removal list (no changes)
- [x] Trailing extra blank line in the artist file handled correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)