### PR TITLE
Add mpd-add-random-artist: exact/loose match toggle, fix crash, tolerant adds

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Collection of scripts related to mpd & mpc.
 | **[mpdsimilar](./mpdsimilar/)** | Fetches similar artist tracks from Last.fm for the currently playing track or every track in the queue, and adds a sample of them to the MPD queue. |
 | **[rm-duplicates-playlist](./rm-duplicates-playlist/)** | Removes duplicate entries from a saved MPD playlist or the current queue, or lists available playlists, combining what the two `mpd-find-dup` scripts each do separately into one tool. |
 | **[rm-artists-playlist](./rm-artists-playlist/)** | Removes songs by a list of artists from a saved MPD playlist or the current queue, or lists available playlists. |
+| **[mpd-add-random-artist](./mpd-add-random-artist/)** | Adds a random sample of a specified artist's tracks to the current MPD queue, matching exactly by default or loosely with `-l`. |
 
 ### Prerequisites
 Listed in each scripts README.md.

--- a/mpd-add-random-artist/README.md
+++ b/mpd-add-random-artist/README.md
@@ -1,0 +1,45 @@
+# Random Artist Track Adder
+
+This script finds tracks by a specified artist and adds a random sample of them to the current MPD queue.
+
+## Features
+
+- Adds a configurable number of random tracks by an artist to the queue (`-t`/`--tracks`, default `10`).
+- Matches the artist **exactly** by default (`mpc find`, case-sensitive), so unrelated artists whose name happens to contain the same substring aren't pulled in.
+- `-l`/`--loose` switches to a substring, case-insensitive match (`mpc search`) instead, for when you're unsure of the exact spelling/capitalization, or want to catch variant taggings of the same artist. Loose matching can also pull in unrelated artists whose name merely contains the given string (e.g. `"Air"` loosely matching `"Air Supply"`), so prefer the exact default when you know the artist name precisely.
+- If an exact match finds nothing, the script suggests retrying with `-l`/`--loose`.
+- A track that fails to add is reported as a warning rather than aborting the whole run — the rest still get added.
+
+## Requirements
+
+- `mpc`
+
+## Usage
+
+```bash
+./mpd-add-random-artist.sh [-t NUMBER] [-l] ARTIST_NAME
+```
+
+- `-t`, `--tracks NUMBER`: Number of random tracks to add (default: `10`).
+- `-l`, `--loose`: Substring, case-insensitive match instead of the default exact match.
+
+Example usage:
+
+```bash
+./mpd-add-random-artist.sh "The Beatles"          # Adds 10 random Beatles tracks (exact match)
+./mpd-add-random-artist.sh -t 5 "Pink Floyd"      # Adds 5 random Pink Floyd tracks
+./mpd-add-random-artist.sh -l "floyd"             # Loose match: catches "Pink Floyd" and similar
+```
+
+## Example Output
+
+```bash
+Added 5 random tracks by Pink Floyd to the queue.
+Queue position: 3/28
+```
+
+## License
+
+This project is licensed under the **GNU General Public License v3.0**.
+
+See [LICENSE](../LICENSE) for more information.

--- a/mpd-add-random-artist/mpd-add-random-artist.sh
+++ b/mpd-add-random-artist/mpd-add-random-artist.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/bash
+#
+# mpd-add-random-artist.sh
+#
+# Uses mpc to find and add random tracks from a specified artist to the
+# MPD queue. By default, matches the artist exactly (via `mpc find`,
+# case-sensitive) -- use -l/--loose for a substring, case-insensitive
+# match (via `mpc search`) if you're unsure of the exact spelling or
+# capitalization, or want to catch variant taggings. Loose matching can
+# also pull in unrelated artists whose name merely contains the given
+# string (e.g. "Air" loosely matching "Air Supply"), so prefer the exact
+# default when you know the artist name precisely.
+#
+# Usage:
+#   ./mpd-add-random-artist.sh [-t NUMBER] [-l] ARTIST_NAME
+#
+# Options:
+#   -t, --tracks NUMBER  Number of random tracks to add (default: 10).
+#   -l, --loose          Substring, case-insensitive match (mpc search)
+#                        instead of the default exact match (mpc find).
+#
+# Examples:
+#   ./mpd-add-random-artist.sh "The Beatles"          # Adds 10 random Beatles tracks (exact match)
+#   ./mpd-add-random-artist.sh -t 5 "Pink Floyd"      # Adds 5 random Pink Floyd tracks
+#   ./mpd-add-random-artist.sh -l "floyd"             # Loose match: catches "Pink Floyd" and similar
+
+set -euo pipefail
+
+# Default number of tracks
+NUM_TRACKS=10
+ARTIST=""
+LOOSE=false
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -t|--tracks)
+            if [[ $# -lt 2 ]]; then
+                echo "Error: -t/--tracks requires an argument." >&2
+                exit 1
+            fi
+            NUM_TRACKS="$2"
+            shift 2
+            ;;
+        -l|--loose)
+            LOOSE=true
+            shift
+            ;;
+        *)
+            # Reject a second positional argument instead of silently
+            # overwriting the artist name.
+            if [[ -n "$ARTIST" ]]; then
+                echo "Error: multiple artist names provided ('$ARTIST' and '$1'). Quote the artist name if it contains spaces." >&2
+                exit 1
+            fi
+            ARTIST="$1"
+            shift
+            ;;
+    esac
+done
+
+# Check if artist was provided
+if [[ -z "$ARTIST" ]]; then
+    echo "Error: Artist name must be provided." >&2
+    echo "Usage: $0 [-t NUMBER] [-l] ARTIST_NAME" >&2
+    exit 1
+fi
+
+# Validate that NUM_TRACKS is a positive integer
+if ! [[ "$NUM_TRACKS" =~ ^[1-9][0-9]*$ ]]; then
+    echo "Error: -t/--tracks must be a positive integer, got '$NUM_TRACKS'." >&2
+    exit 1
+fi
+
+# Confirm mpc is available
+if ! command -v mpc &>/dev/null; then
+    echo "Error: required command 'mpc' not found in PATH." >&2
+    exit 1
+fi
+
+# Exact match (mpc find) by default; substring, case-insensitive match
+# (mpc search) with -l/--loose.
+MPC_MATCH_CMD="find"
+if [[ "$LOOSE" == true ]]; then
+    MPC_MATCH_CMD="search"
+fi
+
+# Find all tracks by the artist using mpc
+ALL_TRACKS=$(mpc "$MPC_MATCH_CMD" artist "$ARTIST")
+
+# Check if any tracks were found (an empty result still yields one line
+# from `echo`, so test the string directly rather than counting lines)
+if [[ -z "$ALL_TRACKS" ]]; then
+    echo "No tracks found for artist: $ARTIST"
+    if [[ "$LOOSE" == false ]]; then
+        echo "Exact match found nothing -- try -l/--loose for a substring match if you're unsure of the exact spelling or capitalization."
+    fi
+    exit 1
+fi
+
+# Count total tracks
+TOTAL_TRACKS=$(echo "$ALL_TRACKS" | wc -l)
+
+# Adjust number of tracks if requested more than available
+if [[ "$NUM_TRACKS" -gt "$TOTAL_TRACKS" ]]; then
+    echo "Only $TOTAL_TRACKS tracks available for $ARTIST. Adding all."
+    NUM_TRACKS="$TOTAL_TRACKS"
+fi
+
+# Add random tracks to queue. A failed individual add is a warning, not a
+# reason to abort the whole run -- one bad path shouldn't stop the rest
+# from being added.
+ADDED_COUNT=0
+while IFS= read -r track; do
+    if mpc add "$track"; then
+        (( ADDED_COUNT++ )) || true
+    else
+        echo "Warning: failed to add '$track' to queue." >&2
+    fi
+done < <(printf '%s\n' "$ALL_TRACKS" | shuf -n "$NUM_TRACKS")
+
+# Show results
+echo "Added $ADDED_COUNT random tracks by $ARTIST to the queue."
+CURRENT_POS=$(mpc status | grep -E '^\[playing\]|^\[paused\]' | awk '{print $2}' | cut -d'/' -f1) || CURRENT_POS="N/A"
+TOTAL_QUEUE=$(mpc playlist | wc -l)
+echo "Queue position: $CURRENT_POS/$TOTAL_QUEUE"


### PR DESCRIPTION
## Summary
Brings the previously-untracked `mpd-add-random-artist.sh` into the repo with fixes:

- Switched the default artist match from `mpc search` (substring, case-insensitive) to `mpc find` (exact, case-sensitive), matching the script's evident intent of adding tracks from *a* specified artist rather than anything whose name happens to contain that substring (e.g. "Air" loosely matching "Air Supply"). Added `-l`/`--loose` to opt back into the original substring-search behavior for when the exact name/spelling isn't known. An exact-match miss suggests retrying with `-l`/`--loose`.
- Fixed a crash: `-t`/`--tracks` with no following value referenced `$2` under `set -u` with nothing to shift, dying with a raw `"$2: unbound variable"` instead of a clean error. Added the same "requires an argument" guard used elsewhere in this repo.
- Made track-adding tolerant of individual failures (warn and continue) instead of aborting the whole run on the first failed `mpc add`, matching `mpdsimilar.sh`'s `add_tracks_to_playlist` precedent. Also switched to counting actual successful adds for the final summary instead of just echoing back the requested count.
- Fixed stale header/usage doc referencing an old filename (`mpd-add-artist.sh`) instead of the actual `mpd-add-random-artist.sh`.

Added a README and a row in the main README table.

## Test plan
- [x] `bash -n` passes
- [x] `-t`/`--tracks` with no value now shows a clean error instead of crashing
- [x] Verified `mpc find`/`mpc search` dispatch and `-l`/`--loose` against a stub `mpc`
- [x] Verified tolerant add-failure counting (partial failures don't abort the run, and the summary reflects actual successes)
- [x] Exact-match-miss correctly suggests `-l`/`--loose`

🤖 Generated with [Claude Code](https://claude.com/claude-code)