### PR TITLE
Add mpd-add-random: config file, symlink support, tolerant adds

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Collection of scripts related to mpd & mpc.
 | **[mpdsimilar](./mpdsimilar/)** | Fetches similar artist tracks from Last.fm for the currently playing track or every track in the queue, and adds a sample of them to the MPD queue. |
 | **[rm-duplicates-playlist](./rm-duplicates-playlist/)** | Removes duplicate entries from a saved MPD playlist or the current queue, or lists available playlists, combining what the two `mpd-find-dup` scripts each do separately into one tool. |
 | **[rm-artists-playlist](./rm-artists-playlist/)** | Removes songs by a list of artists from a saved MPD playlist or the current queue, or lists available playlists. |
+| **[mpd-add-random](./mpd-add-random/)** | Adds a random selection of tracks from the local music library to the current MPD queue. |
 
 ### Prerequisites
 Listed in each scripts README.md.

--- a/mpd-add-random/.gitignore
+++ b/mpd-add-random/.gitignore
@@ -1,0 +1,2 @@
+# Ignore a locally-created live config; only mpd-add-random.conf.example is tracked
+mpd-add-random.conf

--- a/mpd-add-random/README.md
+++ b/mpd-add-random/README.md
@@ -1,0 +1,51 @@
+# Random Track Adder
+
+This script adds a random selection of tracks from the local music library to the current MPD queue.
+
+## Features
+
+- Adds a configurable number of random tracks (`-t`/`--tracks`, default `10`) from anywhere in the library, not tied to a specific artist (see [`mpd-add-random-artist`](../mpd-add-random-artist/) for that).
+- Matches `.mp3`, `.flac`, `.ogg`, `.m4a`, `.opus`, `.wav`, `.wma`, and `.aac` files.
+- Follows symlinks, so a symlinked audio file or directory inside the music library is included rather than silently skipped.
+- A track that fails to add is reported as a warning rather than aborting the whole run — the rest still get added.
+
+## Requirements
+
+- `mpc`
+- `find`, `shuf` (present on virtually any Linux system by default)
+
+## Configuration
+
+Settings live in `~/.config/mpd-add-random/mpd-add-random.conf`, seeded automatically from [`mpd-add-random.conf.example`](./mpd-add-random.conf.example) the first time you run the script. Edit the copy in `~/.config/mpd-add-random/`, not the template.
+
+- `MUSIC_DIR`: local music library path. **Must match MPD's own `music_directory`** — tracks are queued via `mpc add` using paths relative to this directory, which only resolve correctly in MPD if this matches its own config.
+
+The script won't run until `MUSIC_DIR` has been changed from its placeholder value.
+
+## Usage
+
+```bash
+./mpd-add-random.sh [-t NUMBER]
+```
+
+- `-t`, `--tracks NUMBER`: Number of random tracks to add (default: `10`).
+- `-h`, `--help`: Show usage and exit.
+
+Example usage:
+
+```bash
+./mpd-add-random.sh -t 5    # Adds 5 random tracks to the queue
+./mpd-add-random.sh         # Defaults to 10 random tracks
+```
+
+## Example Output
+
+```bash
+Added 5 random tracks to the queue.
+```
+
+## License
+
+This project is licensed under the **GNU General Public License v3.0**.
+
+See [LICENSE](../LICENSE) for more information.

--- a/mpd-add-random/mpd-add-random.conf.example
+++ b/mpd-add-random/mpd-add-random.conf.example
@@ -1,0 +1,10 @@
+# mpd-add-random.conf
+#
+# Copied to ~/.config/mpd-add-random/mpd-add-random.conf on first run if
+# that file doesn't already exist. Edit the copy there, not this template.
+
+# Local music library path. Must match MPD's own music_directory -- tracks
+# are queued via `mpc add` using paths relative to this directory, which
+# only resolve correctly in MPD if this matches its own config. No
+# trailing slash.
+MUSIC_DIR="/path/to/your/music/directory"

--- a/mpd-add-random/mpd-add-random.sh
+++ b/mpd-add-random/mpd-add-random.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/bash
+#
+# mpd-add-random.sh
+#
+# Adds a random selection of tracks from the local music library to the
+# current MPD queue, using paths relative to MUSIC_DIR (as required by mpc).
+#
+# Usage:
+#   ./mpd-add-random.sh [-t NUMBER]
+#
+# Options:
+#   -t, --tracks NUMBER  Number of random tracks to add (default: 10).
+#
+# Configuration:
+#   MUSIC_DIR lives in ~/.config/mpd-add-random/mpd-add-random.conf, seeded
+#   from mpd-add-random.conf.example (shipped alongside this script) on
+#   first run.
+#
+# Examples:
+#   ./mpd-add-random.sh -t 5    # Adds 5 random tracks to the queue
+#   ./mpd-add-random.sh         # Defaults to 10 random tracks
+
+set -euo pipefail
+
+# Number of tracks to add. Defaults to 10 if not provided.
+NUM_TRACKS=10
+
+display_help() {
+    cat <<HELP
+Usage: $(basename "$0") [-t NUMBER]
+
+Adds a random selection of tracks from the local music library (MUSIC_DIR,
+see mpd-add-random.conf) to the current MPD queue.
+
+Options:
+  -t, --tracks NUMBER  Number of random tracks to add (default: 10).
+  -h, --help           Show this help message.
+HELP
+    exit 0
+}
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -t|--tracks)
+            if [[ $# -lt 2 ]]; then
+                echo "Error: -t/--tracks requires an argument." >&2
+                exit 1
+            fi
+            NUM_TRACKS="$2"
+            shift 2
+            ;;
+        -h|--help) display_help ;;
+        *)
+            echo "Unknown option: $1" >&2
+            display_help
+            ;;
+    esac
+done
+
+# Validate that NUM_TRACKS is a positive integer
+if ! [[ "$NUM_TRACKS" =~ ^[1-9][0-9]*$ ]]; then
+    echo "Error: -t/--tracks must be a positive integer, got '$NUM_TRACKS'." >&2
+    exit 1
+fi
+
+# Confirm required tools are available
+for cmd in mpc find shuf; do
+    if ! command -v "$cmd" &>/dev/null; then
+        echo "Error: required command '$cmd' not found in PATH." >&2
+        exit 1
+    fi
+done
+
+# Config lives in ~/.config/mpd-add-random/mpd-add-random.conf, seeded from
+# the mpd-add-random.conf.example template shipped alongside this script
+# on first run.
+CONFIG_DIR="$HOME/.config/mpd-add-random"
+CONFIG_FILE="$CONFIG_DIR/mpd-add-random.conf"
+
+if [[ ! -f "$CONFIG_FILE" ]]; then
+    mkdir -p "$CONFIG_DIR"
+    cp "$(dirname "$0")/mpd-add-random.conf.example" "$CONFIG_FILE"
+    echo "Created $CONFIG_FILE -- edit it with your music directory, then run this again." >&2
+    exit 1
+fi
+
+# shellcheck source=mpd-add-random.conf.example
+source "$CONFIG_FILE"
+
+if [[ "$MUSIC_DIR" == "/path/to/your/music/directory" ]]; then
+    echo "Error: $CONFIG_FILE still has a placeholder MUSIC_DIR value. Edit it first." >&2
+    exit 1
+fi
+
+# Confirm the music directory exists
+if [[ ! -d "$MUSIC_DIR" ]]; then
+    echo "Error: music directory '$MUSIC_DIR' does not exist. Check MUSIC_DIR in $CONFIG_FILE." >&2
+    exit 1
+fi
+
+# Build a NUL-delimited array of all audio files, safe for filenames
+# containing spaces, newlines, or other unusual characters. -L follows
+# symlinks, so symlinked audio files (and directories of them) are included
+# rather than silently skipped.
+TRACKS=()
+while IFS= read -r -d '' track; do
+    TRACKS+=("$track")
+done < <(find -L "$MUSIC_DIR" -type f \
+    \( -iname "*.mp3" -o -iname "*.flac" -o -iname "*.ogg" -o -iname "*.m4a" \
+       -o -iname "*.opus" -o -iname "*.wav" -o -iname "*.wma" -o -iname "*.aac" \) \
+    -print0)
+
+TOTAL_TRACKS="${#TRACKS[@]}"
+
+if [[ "$TOTAL_TRACKS" -eq 0 ]]; then
+    echo "Error: no audio files found under '$MUSIC_DIR'." >&2
+    exit 1
+fi
+
+if [[ "$NUM_TRACKS" -gt "$TOTAL_TRACKS" ]]; then
+    echo "There are only $TOTAL_TRACKS tracks available. Adding all available tracks."
+    NUM_TRACKS="$TOTAL_TRACKS"
+fi
+
+# Randomly select NUM_TRACKS tracks (NUL-delimited to preserve odd filenames)
+# and queue each one with a path relative to MUSIC_DIR, as mpc expects. A
+# plain prefix strip is used rather than `realpath`, which would resolve a
+# symlinked subdirectory to its physical target -- MPD's own database
+# indexes such tracks under the symlink's name (as found by `find -L`
+# above), not its target, so resolving it here would build a path outside
+# MUSIC_DIR that MPD wouldn't recognize. A failed individual add is a
+# warning, not a reason to abort the whole run -- one bad path shouldn't
+# stop the rest from being added.
+ADDED_COUNT=0
+while IFS= read -r -d '' track; do
+    relative_path="${track#"$MUSIC_DIR"/}"
+    if mpc add "$relative_path"; then
+        (( ADDED_COUNT++ )) || true
+    else
+        echo "Warning: failed to add '$relative_path' to queue." >&2
+    fi
+done < <(printf '%s\0' "${TRACKS[@]}" | shuf -z -n "$NUM_TRACKS")
+
+echo "Added $ADDED_COUNT random tracks to the queue."


### PR DESCRIPTION
## Summary
Brings the previously-untracked `mpd-add-random.sh` into the repo with fixes:

- Moved the hardcoded personal `MUSIC_DIR` into a gitignored `~/.config/mpd-add-random/mpd-add-random.conf` seeded from a tracked `.conf.example`, with a placeholder guard, matching the rest of this repo. Documented that `MUSIC_DIR` must match MPD's own `music_directory` — previously unstated, even though `mpc add` silently depends on it.
- Converted the number-of-tracks positional argument to `-t`/`--tracks`, matching `mpd-add-random-artist.sh`'s flag style (#62). Added `-h`/`--help`.
- Made track-adding tolerant of individual failures (warn and continue) instead of aborting the whole run on the first failed `mpc add`, and added a final "Added N tracks" summary — previously there was no completion message of any kind.
- Expanded the matched file types beyond `mp3`/`flac`/`ogg` to also include `m4a`/`opus`/`wav`/`wma`/`aac`.
- `find` now follows symlinks (`-L`) so a symlinked audio file/directory in the library isn't silently skipped. This surfaced a real bug during testing: the relative path handed to `mpc add` was computed via `realpath --relative-to`, which resolves symlinks to their physical target — for a symlinked subdirectory, that produces a path (e.g. `../realdir/Artist/track.mp3`) outside `MUSIC_DIR` that MPD's own database wouldn't recognize, since MPD indexes symlinked tracks under the symlink's name, not its target. Fixed by using a plain prefix strip instead of `realpath`, dropping the `realpath` dependency entirely.

Added a README and a row in the main README table.

## Test plan
- [x] `bash -n` passes
- [x] `-h`, `-t`/`--tracks` validation (missing value, non-integer) all produce clean errors
- [x] First run seeds the config and exits with instructions; rejects the placeholder `MUSIC_DIR`
- [x] End-to-end test with a fake library: discovers mixed audio formats, follows a symlinked subdirectory, correctly excludes non-audio files
- [x] **Symlink bug verified fixed**: symlinked track resolves to a path inside `MUSIC_DIR` (`ArtistB-link/track.opus`), not escaping it via the physical target
- [x] Tolerant add-failure counting verified (partial failures don't abort the run, summary reflects actual successes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)