### PR TITLE
Fix stale mpctt references left over from the mpd-tray-icon rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Collection of scripts related to mpd & mpc.
 | **[rm-artists-playlist](./rm-artists-playlist/)** | Removes songs by a list of artists from a saved MPD playlist or the current queue, or lists available playlists. |
 | **[mpd-add-random-artist](./mpd-add-random-artist/)** | Adds a random sample of a specified artist's tracks to the current MPD queue, matching exactly by default or loosely with `-l`. |
 | **[mpd-add-random](./mpd-add-random/)** | Adds a random selection of tracks from the local music library to the current MPD queue. |
-| **[mpctt](./mpctt/)** | A GTK3 tray icon showing the currently playing MPD track, with Play/Pause/Next/Previous controls. |
+| **[mpd-tray-icon](./mpd-tray-icon/)** | A GTK3 tray icon showing the currently playing MPD track, with Play/Pause/Next/Previous controls. |
 
 ### Prerequisites
 Listed in each scripts README.md.

--- a/mpd-tray-icon/README.md
+++ b/mpd-tray-icon/README.md
@@ -13,7 +13,7 @@ A GTK3 tray icon showing the currently playing MPD track in its tooltip/menu, wi
 MPD must already be running — the script checks on startup and exits if it isn't.
 
 ```bash
-./mpctt.py
+./mpd-tray-icon.py
 ```
 
 The tray icon's label/tooltip shows the current track (or "Stopped"/"MPD not running" as appropriate), and updates automatically whenever playback state changes (blocking on `mpc idle player` in a background thread — no polling). Left-click the icon for the menu:


### PR DESCRIPTION
## Summary
PR #64's follow-up rename commit (`fcb044f`) only renamed the directory/script files — the main README's table row and the usage example inside `mpd-tray-icon/README.md` still said "mpctt" and linked to the now-nonexistent `./mpctt/` path. Root cause: `git add -A README.md mpctt/ mpd-tray-icon/` errored on the already-renamed `mpctt/` pathspec, which silently skipped staging `README.md` along with it, and that went unnoticed before committing.

Fixes both leftover references:
- Main `README.md` table row: `mpctt` → `mpd-tray-icon`, link path corrected
- `mpd-tray-icon/README.md` usage example: `./mpctt.py` → `./mpd-tray-icon.py`

## Test plan
- [x] `grep -rn "mpctt" .` across the repo now returns nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)