### PR TITLE
Add mpd-radio-tray: config file, visible MPD-down feedback, timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Collection of scripts related to mpd & mpc.
 | **[mpd-add-random-artist](./mpd-add-random-artist/)** | Adds a random sample of a specified artist's tracks to the current MPD queue, matching exactly by default or loosely with `-l`. |
 | **[mpd-add-random](./mpd-add-random/)** | Adds a random selection of tracks from the local music library to the current MPD queue. |
 | **[mpd-tray-icon](./mpd-tray-icon/)** | A GTK3 tray icon showing the currently playing MPD track, with Play/Pause/Next/Previous controls. |
+| **[mpd-radio-tray](./mpd-radio-tray/)** | A PyQt5 system tray app for managing and playing categorized internet radio station URLs with MPD, similar to RadioTray-NG. |
 
 ### Prerequisites
 Listed in each scripts README.md.

--- a/mpd-radio-tray/.gitignore
+++ b/mpd-radio-tray/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+
+# Personal station list and settings; only the .example templates are tracked
+stations.txt
+mpd-radio-tray.conf

--- a/mpd-radio-tray/README.md
+++ b/mpd-radio-tray/README.md
@@ -1,0 +1,44 @@
+# MPD Radio Tray
+
+A PyQt5 system tray app (similar to RadioTray-NG) for managing categorized internet radio station URLs with MPD.
+
+## Features
+
+- Tray menu with Stop, categorized stations (submenus), Refresh, and Exit.
+- A visible tray notification (and updated tooltip) if MPD isn't reachable — at startup, and whenever loading/stopping a station fails — rather than only printing to a terminal nobody's watching.
+- MPD calls use a 5-second timeout, so a hung or unreachable server can't freeze the tray app.
+
+## Requirements
+
+- `mpc`-compatible MPD server
+- PyQt5 (e.g. `sudo apt install python3-pyqt5`)
+- `python-mpd2` (e.g. `pip install python-mpd2`)
+
+## Configuration
+
+Settings live in `~/.config/mpd-radio-tray/mpd-radio-tray.conf`, seeded automatically from [`mpd-radio-tray.conf.example`](./mpd-radio-tray.conf.example) the first time you run the script. Edit the copy in `~/.config/mpd-radio-tray/`, not the template.
+
+- `mpd_host`, `mpd_port`: MPD server address. Default `localhost`/`6600`.
+- `icon_path`: path to a custom tray icon image. Leave blank to use the desktop theme's `media-playback-start` icon.
+
+Your station list lives in `~/.config/mpd-radio-tray/stations.txt`, seeded from [`stations.txt.example`](./stations.txt.example) (with placeholder URLs) the first time you run the script. Edit the copy in `~/.config/mpd-radio-tray/` to add your own stations, one per line:
+
+```
+category|display name|stream url
+```
+
+Blank lines and lines starting with `#` are ignored.
+
+## Usage
+
+```bash
+./mpd-radio-tray.py
+```
+
+Left-click the tray icon for the menu. Click a station under its category to play it, "Stop" to stop playback, "Refresh" to reload the station list after editing it, and "Exit" to quit.
+
+## License
+
+This project is licensed under the **GNU General Public License v3.0**.
+
+See [LICENSE](../LICENSE) for more information.

--- a/mpd-radio-tray/mpd-radio-tray.conf.example
+++ b/mpd-radio-tray/mpd-radio-tray.conf.example
@@ -1,0 +1,11 @@
+[mpd-radio-tray]
+# Copied to ~/.config/mpd-radio-tray/mpd-radio-tray.conf on first run if
+# that file doesn't already exist. Edit the copy there, not this template.
+
+# MPD server host and port.
+mpd_host = localhost
+mpd_port = 6600
+
+# Path to a custom tray icon image. Leave blank to use the desktop theme's
+# "media-playback-start" icon instead.
+icon_path =

--- a/mpd-radio-tray/mpd-radio-tray.py
+++ b/mpd-radio-tray/mpd-radio-tray.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""
+MPD Radio Tray
+
+A system tray app (similar to RadioTray-NG) for managing categorized radio station URLs
+with MPD (Music Player Daemon). Offers quick control via tray menu for:
+
+- Stopping playback
+- Categorized stations
+- Refreshing station list
+- Exiting application
+
+Uses `python-mpd2` internally.
+
+Configuration:
+    Settings (MPD host/port, optional custom tray icon) live in
+    ~/.config/mpd-radio-tray/mpd-radio-tray.conf, seeded from
+    mpd-radio-tray.conf.example on first run. The station list lives in
+    ~/.config/mpd-radio-tray/stations.txt, seeded from stations.txt.example.
+"""
+
+import configparser
+import os
+import shutil
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Optional, Dict, List, Tuple
+
+from PyQt5.QtWidgets import QApplication, QMenu, QSystemTrayIcon, QAction
+from PyQt5.QtGui import QIcon, QCursor
+from mpd import MPDClient
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+CONFIG_DIR = Path.home() / ".config" / "mpd-radio-tray"
+CONFIG_FILE = CONFIG_DIR / "mpd-radio-tray.conf"
+STATIONS_FILE = CONFIG_DIR / "stations.txt"
+
+# Seconds to wait on an MPD connection/command before giving up, so a hung
+# or unreachable server can't freeze the GUI (Qt's event loop is
+# single-threaded, and every MPD call here runs synchronously on it).
+MPD_TIMEOUT = 5
+
+
+def load_config() -> Dict[str, object]:
+    """
+    Seed ~/.config/mpd-radio-tray/ from the .example templates shipped
+    alongside this script on first run, then load settings from the config
+    file there.
+    """
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+
+    if not CONFIG_FILE.exists():
+        shutil.copy(SCRIPT_DIR / "mpd-radio-tray.conf.example", CONFIG_FILE)
+        print(f"[Info] Created {CONFIG_FILE} -- edit it to customize settings.")
+
+    if not STATIONS_FILE.exists():
+        shutil.copy(SCRIPT_DIR / "stations.txt.example", STATIONS_FILE)
+        print(f"[Info] Created {STATIONS_FILE} -- edit it to add your own stations.")
+
+    parser = configparser.ConfigParser()
+    parser.read(CONFIG_FILE)
+
+    return {
+        "mpd_host": parser.get("mpd-radio-tray", "mpd_host", fallback="localhost"),
+        "mpd_port": parser.getint("mpd-radio-tray", "mpd_port", fallback=6600),
+        "icon_path": parser.get("mpd-radio-tray", "icon_path", fallback="").strip(),
+    }
+
+
+CONFIG = load_config()
+
+
+def connect_mpd(tray_icon: Optional["MPDTrayApp"] = None) -> Optional[MPDClient]:
+    """Connect to the MPD server and return the client instance."""
+    client = MPDClient()
+    client.timeout = MPD_TIMEOUT
+    try:
+        client.connect(CONFIG["mpd_host"], CONFIG["mpd_port"])
+        return client
+    except Exception as e:
+        message = f"Could not connect to MPD: {e}"
+        print(f"[MPD Error] {message}")
+        if tray_icon:
+            tray_icon.notify_error(message)
+        return None
+
+
+def load_stations() -> Dict[str, List[Tuple[str, str]]]:
+    """
+    Load stations from file, grouped by category.
+
+    Returns:
+        Dictionary of categories to list of (name, url) tuples.
+    """
+    stations_by_category = defaultdict(list)
+
+    if not STATIONS_FILE.exists():
+        print(f"[Warning] Station file '{STATIONS_FILE}' not found.")
+        return stations_by_category
+
+    with open(STATIONS_FILE, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            parts = line.split("|", 2)
+            if len(parts) == 3:
+                category, name, url = parts
+                stations_by_category[category].append((name, url))
+            else:
+                print(f"[Warning] Malformed station line: {line}")
+
+    return stations_by_category
+
+
+def load_station(url: str, tray_icon: Optional["MPDTrayApp"] = None) -> None:
+    """
+    Load and play a radio URL using MPD.
+
+    Args:
+        url: The radio stream URL to play.
+        tray_icon: Tray icon to surface errors on, if any.
+    """
+    client = connect_mpd(tray_icon)
+    if not client:
+        return
+
+    try:
+        client.clear()
+        client.add(url)
+        client.play()
+        print(f"[Info] Now playing: {url}")
+    except Exception as e:
+        message = f"Failed to load URL: {e}"
+        print(f"[MPD Error] {message}")
+        if tray_icon:
+            tray_icon.notify_error(message)
+    finally:
+        client.close()
+        client.disconnect()
+
+
+def stop_playback(tray_icon: Optional["MPDTrayApp"] = None) -> None:
+    """Stop MPD playback and clear the queue."""
+    client = connect_mpd(tray_icon)
+    if not client:
+        return
+
+    try:
+        client.stop()
+        client.clear()
+        print("[Info] Playback stopped.")
+    except Exception as e:
+        message = f"Failed to stop playback: {e}"
+        print(f"[MPD Error] {message}")
+        if tray_icon:
+            tray_icon.notify_error(message)
+    finally:
+        client.close()
+        client.disconnect()
+
+
+class MPDTrayApp(QSystemTrayIcon):
+    """Main tray application class."""
+
+    def __init__(self, icon: QIcon, parent=None):
+        super().__init__(icon, parent)
+        self.menu = QMenu()
+        self.refresh_menu()
+        self.setContextMenu(self.menu)
+        self.setToolTip("MPD Radio Tray")
+        self.activated.connect(self.on_activate)
+        self.check_mpd_connection()
+
+    def check_mpd_connection(self) -> None:
+        """
+        Verify MPD is reachable at startup and give a visible indication
+        (tray notification + tooltip) if it isn't, rather than staying
+        silent until the user clicks a station and wonders why nothing
+        happens. The tray icon and menu still come up either way, so the
+        user can start MPD and hit Refresh without restarting this app.
+        """
+        client = connect_mpd()
+        if client:
+            client.close()
+            client.disconnect()
+        else:
+            self.setToolTip("MPD Radio Tray (MPD not running)")
+            self.notify_error("Could not connect to MPD -- is it running?")
+
+    def notify_error(self, message: str) -> None:
+        """Surface an error via a tray balloon notification, since print()
+        output is invisible when this app is launched from a desktop
+        launcher with no attached terminal."""
+        self.showMessage("MPD Radio Tray", message, QSystemTrayIcon.Warning, 5000)
+
+    def refresh_menu(self) -> None:
+        """Rebuild the tray menu from station file."""
+        # QMenu.clear() removes actions from the menu but doesn't
+        # necessarily delete objects created with an explicit parent, so
+        # explicitly release the previous rebuild's actions (and any
+        # submenus they represent) first to avoid leaking them each time
+        # this is called (e.g. via repeated manual Refresh clicks).
+        for action in self.menu.actions():
+            submenu = action.menu()
+            if submenu is not None:
+                submenu.deleteLater()
+            action.deleteLater()
+        self.menu.clear()
+
+        stop_action = QAction("Stop", self.menu)
+        stop_action.triggered.connect(lambda: stop_playback(self))
+        self.menu.addAction(stop_action)
+
+        stations_by_category = load_stations()
+        for category, stations in stations_by_category.items():
+            category_menu = QMenu(category, self.menu)
+            for name, url in stations:
+                action = QAction(name, category_menu)
+                action.triggered.connect(lambda _, u=url: load_station(u, self))
+                category_menu.addAction(action)
+            self.menu.addMenu(category_menu)
+
+        refresh_action = QAction("Refresh", self.menu)
+        refresh_action.triggered.connect(self.refresh_menu)
+        self.menu.addAction(refresh_action)
+
+        exit_action = QAction("Exit", self.menu)
+        exit_action.triggered.connect(QApplication.quit)
+        self.menu.addAction(exit_action)
+
+    def on_activate(self, reason: QSystemTrayIcon.ActivationReason) -> None:
+        """Show context menu on left click."""
+        if reason == QSystemTrayIcon.Trigger:
+            self.contextMenu().popup(QCursor.pos())
+
+
+def create_icon() -> QIcon:
+    """Load the tray icon."""
+    icon_path = CONFIG["icon_path"]
+    if icon_path and os.path.exists(icon_path):
+        return QIcon(icon_path)
+    return QIcon.fromTheme("media-playback-start")
+
+
+def main() -> None:
+    """Application entry point."""
+    app = QApplication(sys.argv)
+    tray_icon = create_icon()
+    tray_app = MPDTrayApp(tray_icon)
+    tray_app.show()
+    sys.exit(app.exec_())
+
+
+if __name__ == "__main__":
+    main()

--- a/mpd-radio-tray/stations.txt.example
+++ b/mpd-radio-tray/stations.txt.example
@@ -1,0 +1,12 @@
+# Radio stations for mpd-radio-tray, one per line: category|name|url
+#
+# Copied to ~/.config/mpd-radio-tray/stations.txt on first run if that file
+# doesn't already exist. Edit the copy there, not this template. Blank
+# lines and lines starting with # are ignored.
+#
+# The URLs below are placeholders -- replace them with real stream URLs
+# for the stations you want.
+
+Ambient|Example Ambient Station|http://example.com/ambient-stream.mp3
+Ambient|Another Ambient Station|http://example.com/ambient-stream-2.mp3
+News|Example News Station|http://example.com/news-stream.mp3


### PR DESCRIPTION
## Summary
Brings the previously-untracked `mpd-radio-tray.py` (PyQt5 station-browser tray app, similar to RadioTray-NG) into the repo with fixes:

- Moved `MPD_HOST`/`MPD_PORT`/`SYSTEM_ICON_PATH` (a hardcoded personal absolute path) into a gitignored `~/.config/mpd-radio-tray/mpd-radio-tray.conf` seeded from a tracked `.conf.example`, matching the rest of this repo. Folded the separate `menu_icon` boolean into `icon_path` itself (empty or missing means "use the theme icon").
- Moved the station list from a hardcoded path next to the script into `~/.config/mpd-radio-tray/stations.txt`, seeded from a tracked `stations.txt.example` with placeholder URLs and documented format.
- Every MPD failure (connect, load station, stop playback) previously only printed to stdout — invisible when launched from a desktop launcher with no attached terminal. Added a `check_mpd_connection()` startup check and a `notify_error()` helper that surfaces failures via a tray balloon notification and an updated tooltip.
- Set an explicit MPD client timeout (5s); previously unset, meaning a hung/unreachable server could block forever inside a synchronous Qt signal handler, freezing the single-threaded GUI.
- Fixed inconsistent malformed-line handling in `load_stations()`: a line with 1 pipe (2 parts) warned, but a line with 0 pipes was silently dropped with no warning at all.
- Parent each station `QAction`/category `QMenu` to the menu it belongs to (not the long-lived tray icon), and explicitly `deleteLater()` the previous rebuild's actions/submenus in `refresh_menu()`, to avoid leaking them each time the menu is rebuilt (e.g. via repeated manual Refresh clicks).

A real, pre-existing `stations.txt` with an actual curated station list was found sitting next to the script (the original hardcoded default location) — migrated (copied, original left untouched) to the new `~/.config/mpd-radio-tray/stations.txt` location so it isn't stranded by the location change, and gitignored alongside the live conf file.

Added a README and a row in the main README table.

## Test plan
- [x] `python3 -m py_compile` passes
- [x] Neither PyQt5 nor `python-mpd2` are installed in this sandbox, so all logic was verified against stubbed `PyQt5`/`mpd` modules
- [x] Config and stations-file seeding from `.example` templates verified
- [x] `connect_mpd()` correctly reports failure and respects the timeout setting
- [x] **MPD-down feedback verified end-to-end**: startup with MPD unreachable updates the tooltip to "MPD Radio Tray (MPD not running)" and fires a tray notification
- [x] Malformed-line detection verified against mixed valid/malformed/no-pipe lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)