### PR TITLE
mpd-radio-tray: add column-header line to stations.txt.example

### DIFF
--- a/mpd-radio-tray/stations.txt.example
+++ b/mpd-radio-tray/stations.txt.example
@@ -7,6 +7,7 @@
 # The URLs below are placeholders -- replace them with real stream URLs
 # for the stations you want.
 
+#Category|Station Name|URL
 Ambient|Example Ambient Station|http://example.com/ambient-stream.mp3
 Ambient|Another Ambient Station|http://example.com/ambient-stream-2.mp3
 News|Example News Station|http://example.com/news-stream.mp3


### PR DESCRIPTION
## Summary
Adds `#Category|Station Name|URL` as a quick field-order reference line directly above the example entries in `stations.txt.example`, matching the format convention from the original `stations.txt` this was ported from in #66.

🤖 Generated with [Claude Code](https://claude.com/claude-code)