### PR TITLE
mpd-radio-tray: note the GNOME Shell tray extension requirement

### DIFF
--- a/mpd-radio-tray/README.md
+++ b/mpd-radio-tray/README.md
@@ -13,6 +13,7 @@ A PyQt5 system tray app (similar to RadioTray-NG) for managing categorized inter
 - `mpc`-compatible MPD server
 - PyQt5 (e.g. `sudo apt install python3-pyqt5`)
 - `python-mpd2` (e.g. `pip install python-mpd2`)
+- A tray host that supports `QSystemTrayIcon`/KStatusNotifierItem. Stock GNOME Shell doesn't — install the "AppIndicator and KStatusNotifierItem Support" extension if the icon doesn't appear. KDE Plasma, XFCE, and most other desktop environments support it natively.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
`QSystemTrayIcon` relies on the same KStatusNotifierItem protocol that stock GNOME Shell dropped native support for, mirroring the note already in `mpd-tray-icon`'s README for its AppIndicator3 dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)