### PR TITLE
setup-path.sh: also offer to create/add ~/bin/music to PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Listed in each scripts README.md.
 
 
 ### Installation
-Run [`./setup-path.sh`](./setup-path.sh) once to check whether a personal bin directory is already on your `PATH`, and, if not, create `~/bin` and add it for you.
+Run [`./setup-path.sh`](./setup-path.sh) once to check whether a personal bin directory is already on your `PATH`, and, if not, create `~/bin` and add it for you. It also offers to create `~/bin/music` and add it to your `PATH` too, for scripts that use it for music-related data files.
 
 Most scripts in this repository are standalone and only need to be copied into a directory on your `$PATH` (e.g. `~/bin` or `~/.local/bin`) and marked executable:
 

--- a/setup-path.sh
+++ b/setup-path.sh
@@ -1,17 +1,46 @@
 #!/usr/bin/bash
 
 # Checks whether a personal bin directory is already on PATH, and if not,
-# offers to create ~/bin and add it. Run this once before following the
-# Installation steps in README.md.
+# offers to create ~/bin and add it. Also checks/offers the same for
+# ~/bin/music, used by some scripts in this repo for music-related data
+# files. Run this once before following the Installation steps in
+# README.md.
 
 set -e  # Exit on error
 
 # Common personal bin directories to check for, in order of preference.
 CANDIDATE_DIRS=("$HOME/bin" "$HOME/.local/bin" "/usr/local/sbin" "/usr/local/bin")
 
+# Pick the shell's rc file so PATH changes survive new shells.
+case "$(basename "${SHELL:-bash}")" in
+    zsh)  RC_FILE="$HOME/.zshrc" ;;
+    bash) RC_FILE="$HOME/.bashrc" ;;
+    *)    RC_FILE="$HOME/.profile" ;;
+esac
+
+# Returns success if $1 is already on PATH.
+on_path() {
+    echo ":$PATH:" | grep -q ":$1:"
+}
+
+# Creates $1 if needed and appends a PATH export for it to RC_FILE, unless
+# one's already there.
+add_dir_to_path() {
+    local dir="$1"
+    mkdir -p "$dir"
+
+    local export_line="export PATH=\"$dir:\$PATH\""
+    if ! grep -qsF "$export_line" "$RC_FILE" 2>/dev/null; then
+        echo "$export_line" >> "$RC_FILE"
+        echo "Created $dir and added it to PATH in $RC_FILE."
+    else
+        echo "Created $dir (PATH entry already present in $RC_FILE)."
+    fi
+}
+
 FOUND_DIR=""
 for dir in "${CANDIDATE_DIRS[@]}"; do
-    if [ -d "$dir" ] && echo ":$PATH:" | grep -q ":$dir:"; then
+    if [ -d "$dir" ] && on_path "$dir"; then
         FOUND_DIR="$dir"
         break
     fi
@@ -19,31 +48,30 @@ done
 
 if [ -n "$FOUND_DIR" ]; then
     echo "Found $FOUND_DIR already on your PATH. Copy scripts there; no changes needed."
-    exit 0
-fi
-
-echo "No personal bin directory (${CANDIDATE_DIRS[*]}) was found on your PATH."
-read -r -p "Create ~/bin and add it to your PATH? [y/N] " REPLY
-
-if [[ ! "$REPLY" =~ ^[Yy]$ ]]; then
-    echo "Skipped. Add a directory to your PATH manually, then see README.md's Installation section."
-    exit 0
-fi
-
-mkdir -p "$HOME/bin"
-
-# Pick the shell's rc file so the PATH change survives new shells.
-case "$(basename "${SHELL:-bash}")" in
-    zsh)  RC_FILE="$HOME/.zshrc" ;;
-    bash) RC_FILE="$HOME/.bashrc" ;;
-    *)    RC_FILE="$HOME/.profile" ;;
-esac
-
-if ! grep -qs 'export PATH="\$HOME/bin:\$PATH"' "$RC_FILE" 2>/dev/null; then
-    echo 'export PATH="$HOME/bin:$PATH"' >> "$RC_FILE"
-    echo "Created ~/bin and added it to PATH in $RC_FILE."
 else
-    echo "Created ~/bin (PATH entry already present in $RC_FILE)."
+    echo "No personal bin directory (${CANDIDATE_DIRS[*]}) was found on your PATH."
+    read -r -p "Create ~/bin and add it to your PATH? [y/N] " REPLY
+
+    if [[ "$REPLY" =~ ^[Yy]$ ]]; then
+        add_dir_to_path "$HOME/bin"
+    else
+        echo "Skipped ~/bin. Add a directory to your PATH manually, then see README.md's Installation section."
+    fi
 fi
 
-echo "Run 'source $RC_FILE' or open a new shell for the change to take effect."
+# ~/bin/music is a separate, optional directory some scripts in this repo
+# use for music-related data files -- handled independently of the
+# general-purpose CANDIDATE_DIRS check above.
+if [ -d "$HOME/bin/music" ] && on_path "$HOME/bin/music"; then
+    echo "Found $HOME/bin/music already on your PATH. No changes needed there."
+else
+    read -r -p "Create ~/bin/music and add it to your PATH too? [y/N] " REPLY
+
+    if [[ "$REPLY" =~ ^[Yy]$ ]]; then
+        add_dir_to_path "$HOME/bin/music"
+    else
+        echo "Skipped ~/bin/music."
+    fi
+fi
+
+echo "Run 'source $RC_FILE' or open a new shell for any changes to take effect."


### PR DESCRIPTION
## Summary
`~/bin/music` is a separate personal directory some scripts in this repo use for music-related data files. `setup-path.sh` now checks/offers to create and PATH-add it too, independently of the existing general-purpose bin-directory check. Factored the create/append-to-PATH logic into a shared `add_dir_to_path()` helper since it's now used for two directories.

## Test plan
- [x] `bash -n` passes
- [x] Fresh run (fake `$HOME`, nothing on PATH) creates both `~/bin` and `~/bin/music` and appends both PATH exports to `.bashrc`
- [x] Re-run with both already on PATH reports "no changes needed" for each, with no duplicate PATH lines appended
- [x] Declining both prompts creates neither directory nor modifies `.bashrc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)