### PR TITLE
mpd_rewind_daemon: add an installer chooser prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,11 @@ chmod +x ~/bin/<script-name>
 
 Check each script's own README for language-specific dependencies (Python, Perl, `mpc`/`python-mpd2`, etc.) before running it.
 
-`mpd_rewind_daemon` ships its own installers instead (`install-xdg-autostart.sh` or `install-systemd.sh` — pick one):
+`mpd_rewind_daemon` ships its own installer instead, prompting you to choose between two methods (`install-xdg-autostart.sh` or `install-systemd.sh`, with a clear recommendation either way):
 
 ```bash
 cd mpd_rewind_daemon
-./install-xdg-autostart.sh
+./install.sh
 ```
 
 See [`mpd_rewind_daemon/README.md`](./mpd_rewind_daemon/) for details.

--- a/install.sh
+++ b/install.sh
@@ -8,11 +8,14 @@
 #    not, offers to create ~/bin and add it. Also checks/offers the same
 #    for ~/bin/music, an optional separate directory for installing this
 #    repo's scripts, kept apart from other personal scripts in ~/bin.
+# 3. Offers to install the optional MPD Rewind Daemon, delegating to its
+#    own installer chooser (autostart vs systemd) if you say yes.
 #
 # Run this once before following the Installation steps in README.md.
 
 set -e  # Exit on error
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 NESTED_CONFIG_ROOT="$HOME/.config/mpd-scripts"
 
 # Scripts that previously stored their own settings directly under
@@ -163,6 +166,29 @@ setup_path() {
     echo "Run 'source $RC_FILE' or open a new shell for any changes to take effect."
 }
 
+# Offers to install the optional MPD Rewind Daemon (not everyone using this
+# repo wants a background daemon running), delegating to its own installer
+# chooser if you say yes. A failure there doesn't abort the rest of this
+# script -- migration and PATH setup have already succeeded by this point,
+# and the daemon can always be installed later via mpd_rewind_daemon/install.sh.
+offer_mpd_rewind_daemon() {
+    local daemon_installer="$SCRIPT_DIR/mpd_rewind_daemon/install.sh"
+
+    if [ ! -x "$daemon_installer" ]; then
+        return
+    fi
+
+    echo
+    read -r -p "Also install the optional MPD Rewind Daemon (auto-rewinds after resuming from pause)? [y/N] " REPLY
+
+    if [[ "$REPLY" =~ ^[Yy]$ ]]; then
+        "$daemon_installer" || echo "mpd_rewind_daemon installation did not complete successfully; you can retry with mpd_rewind_daemon/install.sh." >&2
+    else
+        echo "Skipped. Run mpd_rewind_daemon/install.sh later if you change your mind."
+    fi
+}
+
 migrate_config_dirs
 setup_path
+offer_mpd_rewind_daemon
 print_migration_summary

--- a/mpd_rewind_daemon/README.md
+++ b/mpd_rewind_daemon/README.md
@@ -22,7 +22,9 @@ MPD Rewind Daemon is a background service that automatically rewinds the current
 
 ## Installation
 
-To install and configure the MPD Rewind Daemon, clone or download this repository, then pick **one** of the following (don't run both):
+To install and configure the MPD Rewind Daemon, clone or download this repository, then pick **one** of the following (don't run both).
+
+Run [`./install.sh`](./install.sh) to be prompted which one you want (defaults to Option A after 30 seconds), or run either script directly if you already know:
 
 ### Option A: XDG autostart (default)
 

--- a/mpd_rewind_daemon/install.sh
+++ b/mpd_rewind_daemon/install.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/bash
+
+# MPD Rewind Daemon installer chooser
+#
+# Prompts you to pick between install-xdg-autostart.sh and
+# install-systemd.sh (see their own headers, or README.md, for full
+# details), then runs the one you choose. Skip this and run either of
+# those two directly if you already know which one you want.
+
+set -e  # Exit on error
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+cd "$SCRIPT_DIR"
+
+cat <<'EOF'
+MPD Rewind Daemon can be installed one of two ways:
+
+  A) XDG autostart (default) -- a plain background process started via a
+     desktop autostart .desktop entry. Works on any desktop session, no
+     systemd required. Pick this unless you have a specific reason to
+     want B: it's simpler, and is the one to use on a minimal/embedded
+     setup or any session without a working `systemd --user`. If it
+     crashes, it stays down until your next login; logs go to its own
+     file (~/.local/state/mpd_rewind_daemon/mpd_rewind_daemon.log).
+
+  B) systemd --user service -- pick this if you want the daemon to
+     automatically restart if it crashes, or want its logs in
+     `journalctl` alongside your other services, and you're on a
+     desktop Linux distro with a normal `systemd --user` session
+     (true for most; not for some minimal/embedded/WSL1 setups).
+
+EOF
+
+read -t 30 -r -p "Install via [A]utostart or [S]ystemd? (default: A, auto-selected in 30s) " choice || true
+echo
+
+case "${choice:-A}" in
+    [Ss]*) exec ./install-systemd.sh ;;
+    *)     exec ./install-xdg-autostart.sh ;;
+esac


### PR DESCRIPTION
## Summary
`install-xdg-autostart.sh` and `install-systemd.sh` already existed as two separate, manually-chosen installers. Added `install.sh` as a chooser in front of them:

- Explains the concrete tradeoff: XDG autostart is simpler and works without `systemd --user` (recommended for minimal/embedded setups or anything without a working `systemd --user` session); the systemd service gives auto-restart-on-crash and `journalctl` logging (recommended if you want process supervision and are on a normal desktop Linux distro).
- Prompts with a 30-second timeout, defaulting to XDG autostart (Option A) if you don't answer in time.
- `exec`s whichever installer you picked. Running either script directly still works unchanged.

Updated both the main README and `mpd_rewind_daemon/README.md` to point at `install.sh` as the primary entry point.

## Test plan
- [x] `bash -n` passes
- [x] All four input paths verified against stubbed installer scripts: `A`, `S`, `s` (lowercase), and no input/timeout (defaults to autostart)

🤖 Generated with [Claude Code](https://claude.com/claude-code)