### PR TITLE
mpd_rewind_daemon: add genre_filter to limit rewinding to certain genres

### DIFF
--- a/mpd_rewind_daemon/README.md
+++ b/mpd_rewind_daemon/README.md
@@ -76,14 +76,18 @@ This reads the PID file and sends a graceful shutdown signal. (`pkill -f mpd_rew
 
 Settings live in `~/.config/mpd-scripts/mpd_rewind_daemon/mpd_rewind_daemon.conf`, seeded automatically from [`mpd_rewind_daemon.conf.example`](./mpd_rewind_daemon.conf.example) the first time you run the script. Edit the copy in `~/.config/mpd-scripts/mpd_rewind_daemon/`, not the template.
 
-| Setting        | Description                                       | Default                 |
-| -------------- | --------------------------------------------------- | ----------------------- |
-| `rewind_tiers` | How far to rewind based on how long you were paused | `5:5,15:15,30:30,60:60` |
-| `mpd_host`     | MPD server hostname/IP                              | `localhost`              |
-| `mpd_port`     | MPD server port                                     | `6600`                   |
-| `mpd_password` | MPD password, if required (leave blank if none)     | *(blank)*                |
+| Setting                 | Description                                          | Default                 |
+| ----------------------- | ----------------------------------------------------- | ----------------------- |
+| `rewind_tiers`          | How far to rewind based on how long you were paused   | `5:5,15:15,30:30,60:60` |
+| `mpd_host`              | MPD server hostname/IP                                | `localhost`              |
+| `mpd_port`              | MPD server port                                       | `6600`                   |
+| `mpd_password`          | MPD password, if required (leave blank if none)       | *(blank)*                |
+| `genre_filter_enabled`  | Limit rewinding to specific genres (see below)        | `False`                  |
+| `genre_filter`          | Comma-separated genres to limit to, if enabled        | `Audiobook,Podcast`      |
 
 `rewind_tiers` is a comma-separated list of `paused_seconds:rewind_seconds` pairs. The longest threshold that's `<=` the actual pause duration wins, so with the default tiers, pausing for 20s rewinds 15s. Pausing for less than the smallest threshold (5s by default) doesn't rewind at all. Add, remove, or change tiers freely — e.g. `10:3,60:10,300:20` for a gentler curve.
+
+`genre_filter_enabled`/`genre_filter` let you restrict rewinding to certain genres instead of every track — e.g. audiobooks and podcasts, leaving regular music alone. Off by default, so rewinding applies to everything regardless of genre until you turn it on. Genre matching is case-insensitive. If enabled, a track with no genre tag (or one not in the list) is never rewound; leaving `genre_filter` empty while enabled disables rewinding entirely.
 
 Two more paths aren't in the config file, since changing them is a less common need — edit `mpd_rewind_daemon.py` directly if you want to:
 

--- a/mpd_rewind_daemon/mpd_rewind_daemon.conf.example
+++ b/mpd_rewind_daemon/mpd_rewind_daemon.conf.example
@@ -17,3 +17,14 @@ mpd_port = 6600
 
 # Leave blank unless your MPD requires a password.
 mpd_password =
+
+# Limit rewinding to specific genres -- e.g. audiobooks/podcasts, leaving
+# regular music playback alone. Off by default: rewinding applies to every
+# track regardless of genre. If enabled, a track with no genre tag, or
+# one not in genre_filter, is never rewound; an empty genre_filter with
+# this enabled disables rewinding entirely.
+genre_filter_enabled = False
+
+# Comma-separated, matched case-insensitively against the track's genre
+# tag. Only consulted when genre_filter_enabled is True.
+genre_filter = Audiobook,Podcast

--- a/mpd_rewind_daemon/mpd_rewind_daemon.py
+++ b/mpd_rewind_daemon/mpd_rewind_daemon.py
@@ -7,7 +7,8 @@ When playback resumes from a paused state, it rewinds the track by a set amount 
 The daemon supports logging and verbose output for debugging purposes.
 
 Configuration:
-- rewind_tiers, mpd_host, mpd_port, mpd_password: see
+- rewind_tiers, mpd_host, mpd_port, mpd_password, genre_filter_enabled,
+  genre_filter: see
   ~/.config/mpd-scripts/mpd_rewind_daemon/mpd_rewind_daemon.conf (seeded
   from mpd_rewind_daemon.conf.example on first run).
 - PID_FILE: Location to store the daemon process ID (PID) (default: "~/.local/state/mpd_rewind_daemon/mpd_rewind_daemon.pid").
@@ -86,11 +87,26 @@ def parse_rewind_tiers(raw):
     tiers.sort(key=lambda tier: tier[0])
     return tiers
 
+def parse_genre_filter(raw):
+    """
+    Parses a comma-separated genre_filter config value into a set of
+    lowercased, trimmed genre names for case-insensitive membership checks.
+
+    Args:
+        raw (str): The raw config value.
+
+    Returns:
+        set[str]: Lowercased genre names (empty if raw has none).
+    """
+    return {genre.strip().lower() for genre in raw.split(",") if genre.strip()}
+
 _config = load_config()
 REWIND_TIERS = parse_rewind_tiers(_config.get("rewind_tiers", fallback=""))
 MPD_HOST = _config.get("mpd_host", fallback="localhost")
 MPD_PORT = _config.getint("mpd_port", fallback=6600)
 MPD_PASSWORD = _config.get("mpd_password", fallback="")
+GENRE_FILTER_ENABLED = _config.getboolean("genre_filter_enabled", fallback=False)
+GENRE_FILTER = parse_genre_filter(_config.get("genre_filter", fallback=""))
 
 def check_permissions():
     """
@@ -236,16 +252,50 @@ class MPDRewindDaemon:
                 break
         return amount
 
+    def current_track_genre_allowed(self):
+        """
+        Returns True if genre_filter_enabled is off, or the currently
+        playing track's genre (case-insensitive) is in genre_filter. A
+        track with no genre tag -- or one not in the list -- is not
+        allowed once filtering is enabled, so an empty genre_filter with
+        filtering enabled disables rewinding entirely.
+
+        Returns:
+            bool: Whether rewind_and_resume should proceed for this track.
+        """
+        if not GENRE_FILTER_ENABLED:
+            return True
+
+        try:
+            current = self.client.currentsong()
+        except Exception as e:
+            self.log(f"Error fetching current song for genre filter: {e}")
+            return False
+
+        genre = current.get("genre", [])
+        # MPD returns a list instead of a plain string when a track has
+        # multiple genre tag values.
+        genres = genre if isinstance(genre, list) else [genre]
+        track_genres = {g.strip().lower() for g in genres if g.strip()}
+
+        return bool(track_genres & GENRE_FILTER)
+
     def rewind_and_resume(self, pause_duration):
         """
         Pauses, rewinds, and resumes playback to ensure proper rewind.
 
         This method pauses the current track, seeks to a rewind position, and resumes playback.
         The rewind amount scales with how long playback was paused (see get_rewind_amount).
+        Skipped entirely if genre_filter_enabled is on and the current
+        track's genre isn't in genre_filter (see current_track_genre_allowed).
 
         Args:
             pause_duration (float): How many seconds playback was paused for.
         """
+        if not self.current_track_genre_allowed():
+            self.log("Current track's genre is not in genre_filter; skipping rewind.")
+            return
+
         seek_back_time = self.get_rewind_amount(pause_duration)
         if seek_back_time <= 0:
             self.log(f"Paused for {pause_duration:.2f}s; too brief to rewind.")


### PR DESCRIPTION
## Summary
- Adds `genre_filter_enabled` (bool, default `False`) and `genre_filter` (comma-separated list) to `mpd_rewind_daemon.conf.example`.
- When enabled, the daemon only rewinds if the currently playing track's genre (case-insensitive) matches one in `genre_filter` — useful for limiting the rewind-on-resume behavior to audiobooks/podcasts while leaving music untouched, or vice versa.
- When disabled (the default), behavior is unchanged — rewinds on every track regardless of genre, matching current behavior for existing users.
- Handles MPD's `genre` tag being either a plain string or a list (multi-valued tag).

## Test plan
- [x] `python3 -m py_compile mpd_rewind_daemon/mpd_rewind_daemon.py`
- [x] Unit-tested `parse_genre_filter()` and `current_track_genre_allowed()` against a fake MPD client covering: exact match, case-insensitive match, list-valued genre, no match, empty genre, missing genre tag
- [x] Confirmed the default (disabled) leaves existing behavior fully unaffected
- [x] Rebased cleanly onto latest `main` with no conflicts after the intervening `install.sh`/volume work merged