### PR TITLE
Add music_queue_manager script

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Collection of scripts related to mpd & mpc.
 | **[mpd-add-random](./mpd-add-random/)** | Adds a random selection of tracks from the local music library to the current MPD queue. |
 | **[mpd-tray-icon](./mpd-tray-icon/)** | A GTK3 tray icon showing the currently playing MPD track, with Play/Pause/Next/Previous controls. |
 | **[mpd-radio-tray](./mpd-radio-tray/)** | A PyQt5 system tray app for managing and playing categorized internet radio station URLs with MPD, similar to RadioTray-NG. |
+| **[music_queue_manager](./music_queue_manager/)** | Manages song ratings and "bad" flags via MPD stickers: rate on a 5- or 10-point scale, flag/unflag broken songs, remove or jump to a random/top-rated song, and list or rescale ratings. |
 
 ### Prerequisites
 Listed in each script's README.md.

--- a/install.sh
+++ b/install.sh
@@ -285,6 +285,7 @@ SIMPLE_SCRIPTS=(
     "mpd-radio-tray|mpd-radio-tray.py|mpd-radio-tray.conf.example stations.txt.example"
     "mpdsimilar|mpdsimilar.sh|mpdsimilar.conf.example"
     "mpd-tray-icon|mpd-tray-icon.py|"
+    "music_queue_manager|music_queue_manager.sh|music_queue_manager.conf.example"
     "rm-artists-playlist|rm-artists-playlist.sh|rm-artists-playlist.conf.example"
     "rm-duplicates-playlist|rm-duplicates-playlist.sh|rm-duplicates-playlist.conf.example"
     "somafm|soma_fm_playlist_fetcher.py|"

--- a/music_queue_manager/.gitignore
+++ b/music_queue_manager/.gitignore
@@ -1,0 +1,2 @@
+# Ignore a locally-created live config; only music_queue_manager.conf.example is tracked
+music_queue_manager.conf

--- a/music_queue_manager/README.md
+++ b/music_queue_manager/README.md
@@ -1,0 +1,117 @@
+# Music Queue Manager
+
+## Description
+This script allows you to interact with the music queue and manage song ratings and statuses using "stickers." The stickers feature is used to label songs, such as marking them as "broken" or applying ratings. The script supports several features including:
+
+- Rating songs on a 5- or 10-point scale.
+- Flagging songs as "bad" (broken), and clearing that flag.
+- Removing the current song from the queue.
+- Listing all songs marked as bad.
+- Jumping to a random song in the queue.
+- Jumping to a top-rated song.
+- Viewing ratings for the whole library or a specific directory.
+- Rescaling all stored ratings after changing the rating scale.
+
+Compatible with clients like Cantata, mpedv, and myMPD.
+
+## Features
+- **Rate songs**: Assign a rating to the currently playing song.
+- **Flag songs as broken**: Mark a song as "bad" if it is broken or problematic.
+- **Unflag songs as broken**: Clear the "bad" flag from the current song.
+- **Remove songs**: Remove the current song from the queue.
+- **Jump to random song**: Skip to a random song in the queue.
+- **Jump to a top-rated song**: Queue and play a top-rated song.
+- **List bad songs**: View all songs marked as "bad" (broken).
+- **List song ratings**: Display ratings for songs across the whole library or within a specified directory.
+- **Rescale ratings**: Convert all stored ratings from one scale to another.
+
+## Requirements
+- `mpc` command-line utility for interacting with MPD.
+
+## Configuration
+On first run, a config file is created at
+`~/.config/mpd-scripts/music_queue_manager/music_queue_manager.conf`, seeded
+from `music_queue_manager.conf.example`. Edit the copy there, not the
+template.
+
+- **RATING_SCALE**: `5` or `10` (default `10`). Sets the maximum value
+  accepted by `rate` and shown in usage. Changing this does not convert
+  ratings already stored under the old scale — run `rescale` afterwards.
+- **TOP_RATED_MODE**: `single` or `random` (default `single`). Controls how
+  `top_rated` breaks ties for the highest rating: always the same song
+  (`single`) or a random pick among the tied songs (`random`).
+
+## Usage
+### General Usage
+```bash
+$ ./music_queue_manager.sh <command> <args>
+```
+
+### Available Commands
+- **remove**: Remove the current song from the queue.
+- **random**: Jump to a random song in the queue.
+- **flag_bad**: Flag the current song as "bad" (broken).
+- **unflag_bad**: Clear the "bad" flag on the current song.
+- **list_bad**: List all songs marked as "bad."
+- **rate <0-N>**: Rate the current song, where N is `RATING_SCALE` from the config file (5 or 10).
+- **ratings [dir]**: List ratings for all songs, optionally scoped to `[dir]`. Omit `[dir]` to list the whole library.
+- **rescale <old> <new>**: Convert every stored rating from the `<old>` scale to the `<new>` scale (e.g. after changing `RATING_SCALE`).
+- **top_rated**: Queue and jump to a top-rated song. Tie-breaking is controlled by `TOP_RATED_MODE`.
+
+### Examples
+- **Remove the current song from the queue**:
+    ```bash
+    $ ./music_queue_manager.sh remove
+    ```
+
+- **Jump to a random song**:
+    ```bash
+    $ ./music_queue_manager.sh random
+    ```
+
+- **Flag the current song as "bad"**:
+    ```bash
+    $ ./music_queue_manager.sh flag_bad
+    ```
+
+- **List all songs marked as "bad"**:
+    ```bash
+    $ ./music_queue_manager.sh list_bad
+    ```
+
+- **Rate the current song** (e.g., a rating of 7):
+    ```bash
+    $ ./music_queue_manager.sh rate 7
+    ```
+
+- **List ratings for songs in a specific directory**:
+    ```bash
+    $ ./music_queue_manager.sh ratings /path/to/music
+    ```
+
+- **List ratings for the whole library**:
+    ```bash
+    $ ./music_queue_manager.sh ratings
+    ```
+
+- **Clear the "bad" flag on the current song**:
+    ```bash
+    $ ./music_queue_manager.sh unflag_bad
+    ```
+
+- **Rescale all ratings after switching from a 10-point to a 5-point scale**:
+    ```bash
+    $ ./music_queue_manager.sh rescale 10 5
+    ```
+
+- **Jump to a top-rated song**:
+    ```bash
+    $ ./music_queue_manager.sh top_rated
+    ```
+
+## License
+
+This project is licensed under the **GNU General Public License v3.0**.
+
+See [LICENSE](../LICENSE) for more information.
+

--- a/music_queue_manager/music_queue_manager.conf.example
+++ b/music_queue_manager/music_queue_manager.conf.example
@@ -1,0 +1,14 @@
+# music_queue_manager.conf
+#
+# Copied to ~/.config/mpd-scripts/music_queue_manager/music_queue_manager.conf on
+# first run if that file doesn't already exist. Edit the copy there, not
+# this template.
+
+# Rating scale for the `rate` command: 5 or 10.
+# Sets the maximum value accepted by `rate` and shown in usage.
+RATING_SCALE=10
+
+# How `top_rated` breaks ties for the highest rating: "single" or "random".
+# single: always jumps to the same song among ties.
+# random: picks randomly among all songs tied for the highest rating.
+TOP_RATED_MODE=single

--- a/music_queue_manager/music_queue_manager.sh
+++ b/music_queue_manager/music_queue_manager.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+set -e
+
+# Script to interact with the music queue and manage song ratings and statuses using "stickers"
+# The stickers feature is used for marking songs with specific labels (e.g., "broken" or "rating").
+# This script supports rating songs, rescaling stored ratings, flagging/unflagging songs as
+# "bad" (broken), removing songs from the queue, listing songs flagged as bad, and jumping to
+# a random or top-rated song in the queue.
+# Ratings are compatible with clients such as Cantata, mpedv, and myMPD.
+
+# Function to display usage instructions
+usage () {
+    # Display the command usage with details of available options
+    echo "$0 <command> <args>"
+    echo -e "\nCommands:"
+    echo -e "    remove              remove current song from queue"
+    echo -e "    random              jump to a random song in queue"
+    echo -e "    flag_bad            flags current song as bad"
+    echo -e "    unflag_bad          clears the bad flag on current song"
+    echo -e "    list_bad            list all songs marked as bad"
+    echo -e "    rate <0-$RATING_SCALE>    rate the current song"
+    echo -e "    ratings [dir]       list ratings for all songs, optionally scoped to [dir]"
+    echo -e "    rescale <old> <new> convert all stored ratings from the <old> scale to <new>"
+    echo -e "    top_rated           jump to a top-rated song (mode set by TOP_RATED_MODE)"
+}
+
+# Function to check if mpc (Music Player Client) is installed
+check_mpc_installed () {
+    # If mpc is not installed, exit the script with an error message
+    if ! command -v mpc &> /dev/null; then
+        echo "mpc command not found. Please install it."
+        exit 1
+    fi
+}
+
+# Function to remove the current song from the queue
+remove () {
+    check_mpc_installed  # Ensure mpc is installed before proceeding
+    # Resolve the current song's actual queue position; it is not always 0
+    # (e.g. after skipping, random mode, or with already-played songs still queued).
+    local position
+    position="$(mpc -f '%position%' current)"
+    if [[ -z "$position" ]]; then
+        echo "No song is currently playing."
+        exit 1
+    fi
+    mpc del "$position"   # Remove the song at its actual position in the queue
+}
+
+# Function to flag the current song as "bad" (broken)
+flag_bad () {
+    check_mpc_installed  # Ensure mpc is installed before proceeding
+    # Get the file path of the current song and set the "broken" sticker to 1 (true)
+    mpc sticker "$(mpc -f '%file%' current)" set broken 1
+}
+
+# Function to clear the "bad" (broken) flag from the current song
+unflag_bad () {
+    check_mpc_installed  # Ensure mpc is installed before proceeding
+    # Get the file path of the current song and delete its "broken" sticker
+    mpc sticker "$(mpc -f '%file%' current)" delete broken
+}
+
+# Function to list all songs that are marked as "bad" (broken)
+list_bad () {
+    check_mpc_installed  # Ensure mpc is installed before proceeding
+    # Search for all songs with the "broken" sticker set
+    mpc sticker "" find broken
+}
+
+# Function to jump to a random song in the queue
+random () {
+    check_mpc_installed  # Ensure mpc is installed before proceeding
+    mpc random on        # Enable random play mode
+    mpc next             # Skip to the next song, which will be random due to random play being enabled
+    mpc random off       # Disable random play mode after jumping to the song
+}
+
+# Function to rate the current song (from 0 to RATING_SCALE)
+rate () {
+    check_mpc_installed  # Ensure mpc is installed before proceeding
+    # Validate that the rating is an integer between 0 and RATING_SCALE
+    if [[ "$1" =~ ^[0-9]+$ ]] && (( $1 >= 0 && $1 <= RATING_SCALE )); then
+        # Apply the rating to the current song
+        mpc sticker "$(mpc -f '%file%' current)" set rating "$1"
+    else
+        # Print an error message and exit if the rating is not valid
+        echo "Invalid rating. Please provide a rating between 0 and $RATING_SCALE."
+        exit 1
+    fi
+}
+
+# Function to list all ratings for songs in a specific directory
+ratings () {
+    check_mpc_installed  # Ensure mpc is installed before proceeding
+    # Search for all songs in the specified directory and list their ratings
+    mpc sticker "$1" find rating
+}
+
+# Function to convert every stored rating from one scale to another
+# (e.g. after changing RATING_SCALE in the config). Run manually since it
+# rewrites sticker data across the whole library.
+rescale () {
+    check_mpc_installed  # Ensure mpc is installed before proceeding
+    local old="$1" new="$2"
+    if [[ ! "$old" =~ ^[0-9]+$ || ! "$new" =~ ^[0-9]+$ || "$old" -le 0 || "$new" -le 0 ]]; then
+        echo "Usage: rescale <old-scale> <new-scale> (both positive integers)"
+        exit 1
+    fi
+    local line file rating new_rating
+    # `mpc sticker "" find rating` prints one "<file>: rating=<value>" line per song
+    while IFS= read -r line; do
+        [[ -z "$line" ]] && continue
+        file="${line%%: rating=*}"
+        rating="${line##*: rating=}"
+        # Round to the nearest integer on the new scale, clamped to [0, new]
+        new_rating=$(( (rating * new + old / 2) / old ))
+        (( new_rating > new )) && new_rating=$new
+        (( new_rating < 0 )) && new_rating=0
+        mpc sticker "$file" set rating "$new_rating"
+    done < <(mpc sticker "" find rating)
+}
+
+# Function to jump to a top-rated song. TOP_RATED_MODE from the config
+# controls whether ties for the highest rating are broken deterministically
+# ("single") or by picking randomly among them ("random").
+top_rated () {
+    check_mpc_installed  # Ensure mpc is installed before proceeding
+    local line file rating max_rating=-1
+    local -a top_files=()
+    while IFS= read -r line; do
+        [[ -z "$line" ]] && continue
+        file="${line%%: rating=*}"
+        rating="${line##*: rating=}"
+        if (( rating > max_rating )); then
+            max_rating=$rating
+            top_files=("$file")
+        elif (( rating == max_rating )); then
+            top_files+=("$file")
+        fi
+    done < <(mpc sticker "" find rating)
+
+    if (( ${#top_files[@]} == 0 )); then
+        echo "No rated songs found."
+        exit 1
+    fi
+
+    local chosen
+    if [[ "$TOP_RATED_MODE" == "random" ]]; then
+        chosen="${top_files[RANDOM % ${#top_files[@]}]}"
+    else
+        chosen="${top_files[0]}"
+    fi
+
+    mpc insert "$chosen"  # Queue it right after the current song
+    mpc next              # Jump to it
+}
+
+# Config lives in
+# ~/.config/mpd-scripts/music_queue_manager/music_queue_manager.conf, seeded
+# from the music_queue_manager.conf.example template shipped alongside this
+# script on first run.
+CONFIG_DIR="$HOME/.config/mpd-scripts/music_queue_manager"
+CONFIG_FILE="$CONFIG_DIR/music_queue_manager.conf"
+
+if [[ ! -f "$CONFIG_FILE" ]]; then
+    mkdir -p "$CONFIG_DIR"
+    cp "$(dirname "$0")/music_queue_manager.conf.example" "$CONFIG_FILE"
+fi
+
+# shellcheck source=music_queue_manager.conf.example
+source "$CONFIG_FILE"
+
+if [[ "$RATING_SCALE" != "5" && "$RATING_SCALE" != "10" ]]; then
+    echo "Error: $CONFIG_FILE has an invalid RATING_SCALE (must be 5 or 10)." >&2
+    exit 1
+fi
+
+if [[ "$TOP_RATED_MODE" != "single" && "$TOP_RATED_MODE" != "random" ]]; then
+    echo "Error: $CONFIG_FILE has an invalid TOP_RATED_MODE (must be single or random)." >&2
+    exit 1
+fi
+
+# Main script logic: Handle different commands passed as arguments
+case "$1" in
+    "remove")     remove ;;       # Remove the current song from the queue
+    "flag_bad")   flag_bad ;;     # Flag the current song as "bad"
+    "unflag_bad") unflag_bad ;;   # Clear the "bad" flag on the current song
+    "random")     random ;;       # Jump to a random song in the queue
+    "list_bad")   list_bad ;;     # List all songs marked as "bad"
+    "rate")     # Handle song rating
+        # Ensure the rating argument is provided
+        if [[ -z "$2" ]]; then
+            echo "Please provide a rating between 0 and $RATING_SCALE."
+            exit 1
+        fi
+        rate "$2" ;;             # Call the rate function with the provided rating
+    "ratings")    ratings "$2" ;; # List ratings for all songs, optionally scoped to a directory
+    "rescale")  # Convert all stored ratings from one scale to another
+        if [[ -z "$2" || -z "$3" ]]; then
+            echo "Usage: rescale <old-scale> <new-scale>"
+            exit 1
+        fi
+        rescale "$2" "$3" ;;
+    "top_rated")  top_rated ;;    # Jump to a top-rated song
+    *)            usage ;;        # Display usage information if an invalid command is provided
+esac


### PR DESCRIPTION
## Summary
- Adds `music_queue_manager`, a script that manages MPD song ratings and "bad" flags via stickers (rate on a configurable 5- or 10-point scale, flag/unflag broken songs, remove the current song, jump to a random or top-rated song, list ratings, and rescale ratings after a scale change).
- Wires it into the root README script table and `install.sh`'s `SIMPLE_SCRIPTS` list, matching the pattern used by the repo's other simple scripts.

## Test plan
- [x] `bash -n music_queue_manager/music_queue_manager.sh` and `bash -n install.sh` both pass.
- [x] Smoke-tested every command (`rate`, `remove`, `flag_bad`/`unflag_bad`, `random`, `list_bad`, `ratings`, `rescale`, `top_rated`) against a stubbed `mpc` binary, including config seeding and both `TOP_RATED_MODE` values.
- [ ] Manual test against a real `mpd`/`mpc` install (not available in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)