### PR TITLE
Add mpd-recent-tracks script

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Collection of scripts related to mpd & mpc.
 | **[mpd-tray-icon](./mpd-tray-icon/)** | A GTK3 tray icon showing the currently playing MPD track, with Play/Pause/Next/Previous controls. |
 | **[mpd-radio-tray](./mpd-radio-tray/)** | A PyQt5 system tray app for managing and playing categorized internet radio station URLs with MPD, similar to RadioTray-NG. |
 | **[music_queue_manager](./music_queue_manager/)** | Manages song ratings and "bad" flags via MPD stickers: rate on a 5- or 10-point scale, flag/unflag broken songs, remove or jump to a random/top-rated song, and list or rescale ratings. |
+| **[mpd-recent-tracks](./mpd-recent-tracks/)** | Generates an M3U playlist (newest first) of music files added or modified in the last N days, optionally capped in size and auto-loaded into MPD, paused or playing. |
 
 ### Prerequisites
 Listed in each script's README.md.

--- a/install.sh
+++ b/install.sh
@@ -283,6 +283,7 @@ SIMPLE_SCRIPTS=(
     "mpd-find-dup|mpd-remove-duplicates-queue.sh mpd-deduplicate-save-and-reload.sh|mpd-deduplicate-save-and-reload.conf.example"
     "mpd-queue-shuffle|mpd-queue-shuffle.sh|mpd-queue-shuffle.conf.example"
     "mpd-radio-tray|mpd-radio-tray.py|mpd-radio-tray.conf.example stations.txt.example"
+    "mpd-recent-tracks|mpd-recent-tracks.sh|mpd-recent-tracks.conf.example"
     "mpdsimilar|mpdsimilar.sh|mpdsimilar.conf.example"
     "mpd-tray-icon|mpd-tray-icon.py|"
     "music_queue_manager|music_queue_manager.sh|music_queue_manager.conf.example"

--- a/mpd-recent-tracks/.gitignore
+++ b/mpd-recent-tracks/.gitignore
@@ -1,0 +1,2 @@
+# Ignore a locally-created live config; only mpd-recent-tracks.conf.example is tracked
+mpd-recent-tracks.conf

--- a/mpd-recent-tracks/README.md
+++ b/mpd-recent-tracks/README.md
@@ -1,0 +1,92 @@
+# MPD Recent Songs Playlist Creator
+
+## Overview
+This script **automatically generates a playlist** of songs **added or modified in the last X days** in your MPD library. It scans the configured music directory, finds recent files, and creates a new `.m3u` playlist, newest song first.
+
+## Features
+- **Customizable time range**: Specify the number of days via `-d/--days` (default: 30).
+- **Newest-first ordering**: Songs are sorted by modification time, most recent first.
+- **Optional size cap**: `-n/--limit` caps the playlist at N songs (still newest first).
+- **Automatic playlist generation**: Finds recent music files and adds them to an `.m3u` playlist, with paths relative to `MUSIC_DIR` so MPD can resolve them.
+- **Optional auto-load into MPD**: `-l/--load` runs `mpc load` on the generated playlist afterwards, leaving it paused unless `-p/--play` is also given.
+- **Cron-friendly quiet mode**: `-q/--quiet` suppresses informational output; errors still print.
+- **Supports common audio formats**: `mp3`, `m4a`, `flac`, `ogg`.
+- **Removes empty playlists**: If no new songs are found, the existing playlist is deleted. A failed run (e.g. a permission error) never touches an existing playlist — the new one is only swapped in once generation succeeds.
+
+## Requirements
+- **MPD (Music Player Daemon)**
+- **Bash (Linux/macOS)**
+- **`find`** utility (with GNU-style `-printf` support)
+- **`mpc`**, only if using `-l/--load`
+
+## Configuration
+On first run, a config file is created at
+`~/.config/mpd-scripts/mpd-recent-tracks/mpd-recent-tracks.conf`, seeded
+from `mpd-recent-tracks.conf.example`. Edit the copy there, not the
+template, then run the script again.
+
+| Variable           | Description                                       | Default Value              |
+|--------------------|----------------------------------------------------|-----------------------------|
+| `PLAYLIST_DIR`     | Path to the MPD playlist directory                 | `/path/to/mpd/playlists`   |
+| `MUSIC_DIR`        | Path to the music directory                        | `/path/to/Music`           |
+| `PLAYLIST_TITLE`   | Name of the generated playlist                     | `Recently Added`           |
+| `DEFAULT_DAYS_OLD` | Default number of days if `-d/--days` isn't given  | `30`                       |
+
+### Playlist Location
+- The generated playlist will be located at:
+  ```
+  [PLAYLIST_DIR]/[PLAYLIST_TITLE].m3u
+  ```
+
+## Usage
+### Running the script:
+```bash
+./mpd-recent-tracks.sh [-d <days>] [-n <limit>] [-q] [-l [-p]]
+```
+
+### Available Options
+- **-d, --days N**: Number of days to look back for recently added/modified files. If not given, uses `DEFAULT_DAYS_OLD` from the config.
+- **-n, --limit N**: Cap the playlist at N songs (newest first).
+- **-q, --quiet**: Suppress informational output; only errors are printed.
+- **-l, --load**: Load the generated playlist into MPD via `mpc load` after creating it. Requires `mpc`. Playback is left paused unless `-p/--play` is also given.
+- **-p, --play**: With `-l/--load`, also start playback via `mpc play` after loading. Errors if given without `-l/--load`.
+- **-h, --help**: Show usage and exit.
+
+### Example Commands:
+- **Generate a playlist for songs added in the last 10 days**:
+  ```bash
+  ./mpd-recent-tracks.sh -d 10
+  ```
+- **Use the configured default days**:
+  ```bash
+  ./mpd-recent-tracks.sh
+  ```
+- **Cap it at the 20 newest songs**:
+  ```bash
+  ./mpd-recent-tracks.sh -n 20
+  ```
+- **Generate and load into MPD paused, suitable for a cron job**:
+  ```bash
+  ./mpd-recent-tracks.sh -q -l
+  ```
+- **Generate, load, and start playing immediately**:
+  ```bash
+  ./mpd-recent-tracks.sh -l -p
+  ```
+
+## Error Handling
+- On first run, or if `PLAYLIST_DIR`/`MUSIC_DIR` in the config are still the placeholder values, the script exits with an error telling you to edit the config.
+- If the playlist or music directories don't exist, the script exits with an error.
+- If `find` fails partway through (e.g. a permission error on a subdirectory), the script reports the failure and leaves any existing playlist untouched.
+- If no recent songs are found (and the scan itself succeeded), the existing playlist is deleted.
+
+## Example Output
+```bash
+Created the 'Recently Added' playlist with 42 songs at /path/to/mpd/playlists/Recently Added.m3u.
+```
+
+## License
+
+This project is licensed under the **GNU General Public License v3.0**.
+
+See [LICENSE](../LICENSE) for more information.

--- a/mpd-recent-tracks/mpd-recent-tracks.conf.example
+++ b/mpd-recent-tracks/mpd-recent-tracks.conf.example
@@ -1,0 +1,19 @@
+# mpd-recent-tracks.conf
+#
+# Copied to ~/.config/mpd-scripts/mpd-recent-tracks/mpd-recent-tracks.conf on
+# first run if that file doesn't already exist. Edit the copy there, not
+# this template.
+
+# Path to the MPD playlist directory. Must match MPD's own
+# playlist_directory. No trailing slash required.
+PLAYLIST_DIR="/path/to/mpd/playlists"
+
+# Path to the music library directory. Must match MPD's own music_directory.
+# No trailing slash required.
+MUSIC_DIR="/path/to/Music"
+
+# Name of the generated playlist, without the .m3u extension.
+PLAYLIST_TITLE="Recently Added"
+
+# Default number of days to look back when -d/--days isn't given.
+DEFAULT_DAYS_OLD=30

--- a/mpd-recent-tracks/mpd-recent-tracks.sh
+++ b/mpd-recent-tracks/mpd-recent-tracks.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/bash
+# Script Name: mpd-recent-tracks.sh
+# Description: Generates an M3U playlist (newest first) of music files added
+#              or modified in the last N days, with paths relative to
+#              MUSIC_DIR so MPD can resolve them.
+# Usage: ./mpd-recent-tracks.sh [-d <days>] [-n <limit>] [-q] [-l [-p]]
+#   -d, --days    Number of days to look back (default: DEFAULT_DAYS_OLD from config)
+#   -n, --limit   Cap the playlist at this many songs (newest first)
+#   -q, --quiet   Suppress informational output; only errors are printed
+#   -l, --load    Load the generated playlist into MPD via `mpc load` (left paused)
+#   -p, --play    With -l/--load, also start playback via `mpc play`
+#   -h, --help    Show usage and exit
+#
+# Configuration:
+#   PLAYLIST_DIR, MUSIC_DIR, PLAYLIST_TITLE, and DEFAULT_DAYS_OLD live in
+#   ~/.config/mpd-scripts/mpd-recent-tracks/mpd-recent-tracks.conf, seeded
+#   from mpd-recent-tracks.conf.example (shipped alongside this script) on
+#   first run.
+
+set -euo pipefail
+
+DAYS_OLD=""
+LIMIT=""
+QUIET=false
+LOAD=false
+PLAY=false
+
+# Print a short error plus a pointer to --help, then exit 1.
+usage() {
+    echo "$1" >&2
+    echo "Try '$(basename "$0") --help' for usage." >&2
+    exit 1
+}
+
+display_help() {
+    cat <<HELP
+Usage: $(basename "$0") [-d <days>] [-n <limit>] [-q] [-l [-p]]
+
+Generates an M3U playlist (newest first) of music files added or modified
+in the last <days> days (default: DEFAULT_DAYS_OLD from config).
+
+Options:
+  -d, --days N    Number of days to look back.
+  -n, --limit N   Cap the playlist at this many songs (newest first).
+  -q, --quiet     Suppress informational output; only errors are printed.
+  -l, --load      Load the generated playlist into MPD via 'mpc load'.
+                  Playback is left paused unless -p/--play is also given.
+  -p, --play      With -l/--load, start playback via 'mpc play' after loading.
+  -h, --help      Show this help message.
+HELP
+    exit 0
+}
+
+# Parse command-line options (both short and long forms)
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -d|--days)
+            if [[ $# -lt 2 ]]; then
+                usage "Error: -d/--days requires an argument."
+            fi
+            DAYS_OLD="$2"
+            shift 2
+            ;;
+        -n|--limit)
+            if [[ $# -lt 2 ]]; then
+                usage "Error: -n/--limit requires an argument."
+            fi
+            LIMIT="$2"
+            shift 2
+            ;;
+        -q|--quiet) QUIET=true; shift ;;
+        -l|--load) LOAD=true; shift ;;
+        -p|--play) PLAY=true; shift ;;
+        -h|--help) display_help ;;
+        *)
+            echo "Unknown option: $1" >&2
+            display_help
+            ;;
+    esac
+done
+
+if [[ -n "$LIMIT" ]] && ! [[ "$LIMIT" =~ ^[0-9]+$ ]]; then
+    usage "Error: -n/--limit must be a non-negative integer, got '$LIMIT'."
+fi
+
+if [[ "$PLAY" == true && "$LOAD" == false ]]; then
+    usage "Error: -p/--play requires -l/--load."
+fi
+
+if [[ "$LOAD" == true ]] && ! command -v mpc &> /dev/null; then
+    echo "Error: -l/--load requires the mpc command, which was not found." >&2
+    exit 1
+fi
+
+# Config lives in
+# ~/.config/mpd-scripts/mpd-recent-tracks/mpd-recent-tracks.conf, seeded
+# from the mpd-recent-tracks.conf.example template shipped alongside this
+# script on first run.
+CONFIG_DIR="$HOME/.config/mpd-scripts/mpd-recent-tracks"
+CONFIG_FILE="$CONFIG_DIR/mpd-recent-tracks.conf"
+
+if [[ ! -f "$CONFIG_FILE" ]]; then
+    mkdir -p "$CONFIG_DIR"
+    cp "$(dirname "$0")/mpd-recent-tracks.conf.example" "$CONFIG_FILE"
+    echo "Created $CONFIG_FILE -- edit it with your playlist/music directories, then run this again." >&2
+    exit 1
+fi
+
+# shellcheck source=mpd-recent-tracks.conf.example
+source "$CONFIG_FILE"
+
+if [[ "$PLAYLIST_DIR" == "/path/to/mpd/playlists" || "$MUSIC_DIR" == "/path/to/Music" ]]; then
+    echo "Error: $CONFIG_FILE still has placeholder PLAYLIST_DIR/MUSIC_DIR values. Edit it first." >&2
+    exit 1
+fi
+
+# Fall back to the configured default if -d/--days wasn't given
+DAYS_OLD="${DAYS_OLD:-$DEFAULT_DAYS_OLD}"
+if ! [[ "$DAYS_OLD" =~ ^[0-9]+$ ]]; then
+    usage "Error: -d/--days must be a non-negative integer, got '$DAYS_OLD'."
+fi
+
+if [[ ! -d "$PLAYLIST_DIR" ]]; then
+    echo "Error: Playlist directory $PLAYLIST_DIR does not exist." >&2
+    exit 1
+fi
+
+if [[ ! -d "$MUSIC_DIR" ]]; then
+    echo "Error: Music directory $MUSIC_DIR does not exist." >&2
+    exit 1
+fi
+
+PLAYLIST_FILE="$PLAYLIST_DIR/${PLAYLIST_TITLE}.m3u"
+# Write to a temp file first so a failed/interrupted run never touches an
+# existing good playlist; only replace it once we know the run succeeded.
+TMP_FILE="$(mktemp "${PLAYLIST_FILE}.XXXXXX")"
+trap 'rm -f "$TMP_FILE"' EXIT
+
+count=0
+
+# Strip the MUSIC_DIR prefix (and any leading slash) from each match so
+# paths in the playlist are relative to MPD's music_directory. Using bash
+# parameter expansion (quoted, so it's a literal prefix match rather than a
+# glob/regex) avoids having to escape MUSIC_DIR against regex metacharacters
+# like "." or "(" that commonly show up in real directory names.
+#
+# `-printf '%T@ %p\0'` prefixes each match with its mtime (epoch seconds) so
+# `sort -z -rn -k1,1` can order the NUL-delimited records newest first
+# without breaking on paths that contain spaces or newlines. The loop keeps
+# reading every record even past -n/--limit (rather than breaking early) so
+# `find`/`sort` upstream never see a broken pipe under `pipefail`.
+if ! find -L "$MUSIC_DIR" -type f -mtime "-${DAYS_OLD}" \( -iname "*.mp3" -o -iname "*.m4a" -o -iname "*.flac" -o -iname "*.ogg" \) -printf '%T@ %p\0' |
+    sort -z -rn -k1,1 |
+    while IFS=' ' read -r -d '' _mtime file; do
+        if [[ -z "$LIMIT" ]] || (( count < LIMIT )); then
+            relative="${file#"$MUSIC_DIR"}"
+            relative="${relative#/}"
+            printf '%s\n' "$relative"
+        fi
+        count=$((count + 1))
+    done > "$TMP_FILE"; then
+    echo "Error: Failed to create playlist. Possible permission issue." >&2
+    exit 1
+fi
+
+# Handle empty results: leave the temp file behind for the trap to clean up,
+# and only remove any existing playlist once we know this run genuinely
+# found nothing (as opposed to having failed, which is caught above).
+if [[ ! -s "$TMP_FILE" ]]; then
+    [[ "$QUIET" == true ]] || echo "Warning: No recent files found. Playlist is empty."
+    rm -f "$PLAYLIST_FILE"
+    exit 0
+fi
+
+mv "$TMP_FILE" "$PLAYLIST_FILE"
+
+TOTAL_FILES=$(wc -l < "$PLAYLIST_FILE")
+[[ "$QUIET" == true ]] || echo "Created the '$PLAYLIST_TITLE' playlist with $TOTAL_FILES songs at $PLAYLIST_FILE."
+
+if [[ "$LOAD" == true ]]; then
+    # `mpc load` only queues the songs; it never starts playback on its own,
+    # so the loaded playlist stays paused unless -p/--play says otherwise.
+    mpc load "$PLAYLIST_TITLE" > /dev/null
+    [[ "$QUIET" == true ]] || echo "Loaded '$PLAYLIST_TITLE' into MPD."
+    if [[ "$PLAY" == true ]]; then
+        mpc play > /dev/null
+        [[ "$QUIET" == true ]] || echo "Started playback."
+    fi
+fi


### PR DESCRIPTION
## Summary
- Adds `mpd-recent-tracks`, which generates an M3U playlist (newest first) of music files added or modified in the last N days, with paths relative to `MUSIC_DIR` so MPD can resolve them.
- Rewrites the original prototype to fix two real bugs: a broken pipefail check that silently swallowed `find` failures, and a `sed`/`awk` regex-escaping bug that broke on music directories containing regex metacharacters (e.g. `Music (2020)/`). Now uses quoted bash parameter expansion for literal (non-regex) prefix stripping instead.
- Adopts the repo's `.conf.example` → `~/.config/mpd-scripts/<name>/<name>.conf` config convention instead of hardcoding paths in the script.
- Adds `-n/--limit` (cap playlist size, still newest-first), `-q/--quiet` (cron-friendly), and `-l/--load` (auto-load into MPD via `mpc load`, left paused unless paired with `-p/--play`, which explicitly errors if given without `-l`).
- Writes to a temp file first and only swaps it in on success, so a failed/interrupted run never clobbers an existing good playlist.
- Wires it into the root README script table and `install.sh`'s `SIMPLE_SCRIPTS` list.

## Test plan
- [x] `bash -n mpd-recent-tracks/mpd-recent-tracks.sh` and `bash -n install.sh` both pass.
- [x] Smoke-tested: config seeding/placeholder detection, newest-first sort order, `-n/--limit` truncation, `-q/--quiet` output suppression, `-l/--load` and `-l -p` against a stubbed `mpc`, `-p` without `-l` erroring, a simulated `find` permission failure leaving an existing playlist untouched, and a genuinely-empty result correctly deleting a stale playlist.
- [ ] Manual test against a real `mpd`/`mpc` install (not available in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)