### PR TITLE
mpd-recent-tracks: configurable extensions, exclude patterns, -r/--random

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -283,7 +283,7 @@ SIMPLE_SCRIPTS=(
     "mpd-find-dup|mpd-remove-duplicates-queue.sh mpd-deduplicate-save-and-reload.sh|mpd-deduplicate-save-and-reload.conf.example"
     "mpd-queue-shuffle|mpd-queue-shuffle.sh|mpd-queue-shuffle.conf.example"
     "mpd-radio-tray|mpd-radio-tray.py|mpd-radio-tray.conf.example stations.txt.example"
-    "mpd-recent-tracks|mpd-recent-tracks.sh|mpd-recent-tracks.conf.example"
+    "mpd-recent-tracks|mpd-recent-tracks.sh|mpd-recent-tracks.conf.example exclude_paths.txt.example"
     "mpdsimilar|mpdsimilar.sh|mpdsimilar.conf.example"
     "mpd-tray-icon|mpd-tray-icon.py|"
     "music_queue_manager|music_queue_manager.sh|music_queue_manager.conf.example"

--- a/mpd-recent-tracks/.gitignore
+++ b/mpd-recent-tracks/.gitignore
@@ -1,2 +1,4 @@
-# Ignore a locally-created live config; only mpd-recent-tracks.conf.example is tracked
+# Ignore locally-created live config/exclude files; only the .example
+# templates are tracked
 mpd-recent-tracks.conf
+exclude_paths.txt

--- a/mpd-recent-tracks/README.md
+++ b/mpd-recent-tracks/README.md
@@ -7,16 +7,19 @@ This script **automatically generates a playlist** of songs **added or modified 
 - **Customizable time range**: Specify the number of days via `-d/--days` (default: 30).
 - **Newest-first ordering**: Songs are sorted by modification time, most recent first.
 - **Optional size cap**: `-n/--limit` caps the playlist at N songs (still newest first).
+- **Optional random sample**: `-r/--random` picks N songs at random from the recent-tracks pool instead of the newest N. Requires `shuf`; cannot be combined with `-n/--limit`.
 - **Automatic playlist generation**: Finds recent music files and adds them to an `.m3u` playlist, with paths relative to `MUSIC_DIR` so MPD can resolve them.
 - **Optional auto-load into MPD**: `-l/--load` runs `mpc load` on the generated playlist afterwards, leaving it paused unless `-p/--play` is also given.
 - **Cron-friendly quiet mode**: `-q/--quiet` suppresses informational output; errors still print.
-- **Supports common audio formats**: `mp3`, `m4a`, `flac`, `ogg`.
+- **Configurable audio formats**: `EXTENSIONS` in the config controls which file extensions are scanned (default: `mp3 m4a flac ogg`).
+- **Exclude patterns**: `exclude_paths.txt` lists glob patterns (relative to `MUSIC_DIR`) to skip, e.g. an entire `Podcasts/` folder.
 - **Removes empty playlists**: If no new songs are found, the existing playlist is deleted. A failed run (e.g. a permission error) never touches an existing playlist — the new one is only swapped in once generation succeeds.
 
 ## Requirements
 - **MPD (Music Player Daemon)**
 - **Bash (Linux/macOS)**
 - **`find`** utility (with GNU-style `-printf` support)
+- **`shuf`**, only if using `-r/--random`
 - **`mpc`**, only if using `-l/--load`
 
 ## Configuration
@@ -25,12 +28,14 @@ On first run, a config file is created at
 from `mpd-recent-tracks.conf.example`. Edit the copy there, not the
 template, then run the script again.
 
-| Variable           | Description                                       | Default Value              |
-|--------------------|----------------------------------------------------|-----------------------------|
-| `PLAYLIST_DIR`     | Path to the MPD playlist directory                 | `/path/to/mpd/playlists`   |
-| `MUSIC_DIR`        | Path to the music directory                        | `/path/to/Music`           |
-| `PLAYLIST_TITLE`   | Name of the generated playlist                     | `Recently Added`           |
-| `DEFAULT_DAYS_OLD` | Default number of days if `-d/--days` isn't given  | `30`                       |
+| Variable           | Description                                                  | Default Value              |
+|--------------------|----------------------------------------------------------------|-----------------------------|
+| `PLAYLIST_DIR`     | Path to the MPD playlist directory                            | `/path/to/mpd/playlists`   |
+| `MUSIC_DIR`        | Path to the music directory                                   | `/path/to/Music`           |
+| `PLAYLIST_TITLE`   | Name of the generated playlist                                | `Recently Added`           |
+| `DEFAULT_DAYS_OLD` | Default number of days if `-d/--days` isn't given             | `30`                       |
+| `EXTENSIONS`       | Space-separated file extensions (no leading dot) to scan for  | `mp3 m4a flac ogg`         |
+| `EXCLUDE_FILE`     | Exclude-patterns filename, resolved relative to the config dir| `exclude_paths.txt`        |
 
 ### Playlist Location
 - The generated playlist will be located at:
@@ -38,15 +43,31 @@ template, then run the script again.
   [PLAYLIST_DIR]/[PLAYLIST_TITLE].m3u
   ```
 
+### Excluding paths
+`exclude_paths.txt` (seeded from `exclude_paths.txt.example` into the same
+config directory as `mpd-recent-tracks.conf`) lists one glob pattern per
+line, matched against each file's path relative to `MUSIC_DIR`:
+
+```
+# Exclude an entire top-level folder
+Podcasts/*
+# Exclude any "Live" subfolder one level down
+*/Live/*
+```
+
+Lines starting with `#` and blank lines are ignored. Leave the file with
+no active patterns to disable exclusion entirely.
+
 ## Usage
 ### Running the script:
 ```bash
-./mpd-recent-tracks.sh [-d <days>] [-n <limit>] [-q] [-l [-p]]
+./mpd-recent-tracks.sh [-d <days>] [-n <limit> | -r <count>] [-q] [-l [-p]]
 ```
 
 ### Available Options
 - **-d, --days N**: Number of days to look back for recently added/modified files. If not given, uses `DEFAULT_DAYS_OLD` from the config.
 - **-n, --limit N**: Cap the playlist at N songs (newest first).
+- **-r, --random N**: Pick N songs at random from the recent-tracks pool, instead of the newest N. Requires `shuf`. Errors if combined with `-n/--limit`.
 - **-q, --quiet**: Suppress informational output; only errors are printed.
 - **-l, --load**: Load the generated playlist into MPD via `mpc load` after creating it. Requires `mpc`. Playback is left paused unless `-p/--play` is also given.
 - **-p, --play**: With `-l/--load`, also start playback via `mpc play` after loading. Errors if given without `-l/--load`.
@@ -64,6 +85,10 @@ template, then run the script again.
 - **Cap it at the 20 newest songs**:
   ```bash
   ./mpd-recent-tracks.sh -n 20
+  ```
+- **Pick 20 random songs from the recent-tracks pool**:
+  ```bash
+  ./mpd-recent-tracks.sh -r 20
   ```
 - **Generate and load into MPD paused, suitable for a cron job**:
   ```bash

--- a/mpd-recent-tracks/exclude_paths.txt.example
+++ b/mpd-recent-tracks/exclude_paths.txt.example
@@ -1,0 +1,6 @@
+# One glob pattern per line, matched against each file's path relative to
+# MUSIC_DIR (the same relative form written into the generated playlist).
+# Standard bash glob syntax applies, e.g.:
+#   Podcasts/*     excludes everything under a top-level Podcasts folder
+#   */Live/*       excludes any "Live" subfolder one level down
+# Lines starting with '#' and blank lines are ignored.

--- a/mpd-recent-tracks/mpd-recent-tracks.conf.example
+++ b/mpd-recent-tracks/mpd-recent-tracks.conf.example
@@ -17,3 +17,13 @@ PLAYLIST_TITLE="Recently Added"
 
 # Default number of days to look back when -d/--days isn't given.
 DEFAULT_DAYS_OLD=30
+
+# Space-separated file extensions (without the leading dot) to include
+# when scanning MUSIC_DIR.
+EXTENSIONS="mp3 m4a flac ogg"
+
+# Name of the exclude-patterns file, resolved relative to this config's
+# own directory (~/.config/mpd-scripts/mpd-recent-tracks/). Seeded from
+# exclude_paths.txt.example on first run. Leave every line commented out
+# (or the file empty) to disable exclusion.
+EXCLUDE_FILE="exclude_paths.txt"

--- a/mpd-recent-tracks/mpd-recent-tracks.sh
+++ b/mpd-recent-tracks/mpd-recent-tracks.sh
@@ -3,24 +3,28 @@
 # Description: Generates an M3U playlist (newest first) of music files added
 #              or modified in the last N days, with paths relative to
 #              MUSIC_DIR so MPD can resolve them.
-# Usage: ./mpd-recent-tracks.sh [-d <days>] [-n <limit>] [-q] [-l [-p]]
+# Usage: ./mpd-recent-tracks.sh [-d <days>] [-n <limit> | -r <count>] [-q] [-l [-p]]
 #   -d, --days    Number of days to look back (default: DEFAULT_DAYS_OLD from config)
 #   -n, --limit   Cap the playlist at this many songs (newest first)
+#   -r, --random  Pick this many songs at random from the recent-tracks pool
 #   -q, --quiet   Suppress informational output; only errors are printed
 #   -l, --load    Load the generated playlist into MPD via `mpc load` (left paused)
 #   -p, --play    With -l/--load, also start playback via `mpc play`
 #   -h, --help    Show usage and exit
 #
 # Configuration:
-#   PLAYLIST_DIR, MUSIC_DIR, PLAYLIST_TITLE, and DEFAULT_DAYS_OLD live in
+#   PLAYLIST_DIR, MUSIC_DIR, PLAYLIST_TITLE, DEFAULT_DAYS_OLD, EXTENSIONS,
+#   and EXCLUDE_FILE live in
 #   ~/.config/mpd-scripts/mpd-recent-tracks/mpd-recent-tracks.conf, seeded
 #   from mpd-recent-tracks.conf.example (shipped alongside this script) on
-#   first run.
+#   first run. EXCLUDE_FILE (default exclude_paths.txt, seeded from
+#   exclude_paths.txt.example) lists glob patterns to skip.
 
 set -euo pipefail
 
 DAYS_OLD=""
 LIMIT=""
+RANDOM_COUNT=""
 QUIET=false
 LOAD=false
 PLAY=false
@@ -34,7 +38,7 @@ usage() {
 
 display_help() {
     cat <<HELP
-Usage: $(basename "$0") [-d <days>] [-n <limit>] [-q] [-l [-p]]
+Usage: $(basename "$0") [-d <days>] [-n <limit> | -r <count>] [-q] [-l [-p]]
 
 Generates an M3U playlist (newest first) of music files added or modified
 in the last <days> days (default: DEFAULT_DAYS_OLD from config).
@@ -42,6 +46,8 @@ in the last <days> days (default: DEFAULT_DAYS_OLD from config).
 Options:
   -d, --days N    Number of days to look back.
   -n, --limit N   Cap the playlist at this many songs (newest first).
+  -r, --random N  Pick N songs at random from the recent-tracks pool,
+                  instead of the newest N. Cannot be combined with -n/--limit.
   -q, --quiet     Suppress informational output; only errors are printed.
   -l, --load      Load the generated playlist into MPD via 'mpc load'.
                   Playback is left paused unless -p/--play is also given.
@@ -68,6 +74,13 @@ while [[ $# -gt 0 ]]; do
             LIMIT="$2"
             shift 2
             ;;
+        -r|--random)
+            if [[ $# -lt 2 ]]; then
+                usage "Error: -r/--random requires an argument."
+            fi
+            RANDOM_COUNT="$2"
+            shift 2
+            ;;
         -q|--quiet) QUIET=true; shift ;;
         -l|--load) LOAD=true; shift ;;
         -p|--play) PLAY=true; shift ;;
@@ -81,6 +94,19 @@ done
 
 if [[ -n "$LIMIT" ]] && ! [[ "$LIMIT" =~ ^[0-9]+$ ]]; then
     usage "Error: -n/--limit must be a non-negative integer, got '$LIMIT'."
+fi
+
+if [[ -n "$RANDOM_COUNT" ]] && ! [[ "$RANDOM_COUNT" =~ ^[0-9]+$ ]]; then
+    usage "Error: -r/--random must be a non-negative integer, got '$RANDOM_COUNT'."
+fi
+
+if [[ -n "$LIMIT" && -n "$RANDOM_COUNT" ]]; then
+    usage "Error: -n/--limit and -r/--random cannot be used together."
+fi
+
+if [[ -n "$RANDOM_COUNT" ]] && ! command -v shuf &> /dev/null; then
+    echo "Error: -r/--random requires the shuf command, which was not found." >&2
+    exit 1
 fi
 
 if [[ "$PLAY" == true && "$LOAD" == false ]]; then
@@ -99,9 +125,11 @@ fi
 CONFIG_DIR="$HOME/.config/mpd-scripts/mpd-recent-tracks"
 CONFIG_FILE="$CONFIG_DIR/mpd-recent-tracks.conf"
 
+SCRIPT_DIR="$(dirname "$0")"
+
 if [[ ! -f "$CONFIG_FILE" ]]; then
     mkdir -p "$CONFIG_DIR"
-    cp "$(dirname "$0")/mpd-recent-tracks.conf.example" "$CONFIG_FILE"
+    cp "$SCRIPT_DIR/mpd-recent-tracks.conf.example" "$CONFIG_FILE"
     echo "Created $CONFIG_FILE -- edit it with your playlist/music directories, then run this again." >&2
     exit 1
 fi
@@ -113,6 +141,23 @@ if [[ "$PLAYLIST_DIR" == "/path/to/mpd/playlists" || "$MUSIC_DIR" == "/path/to/M
     echo "Error: $CONFIG_FILE still has placeholder PLAYLIST_DIR/MUSIC_DIR values. Edit it first." >&2
     exit 1
 fi
+
+if [[ -z "${EXTENSIONS// }" ]]; then
+    echo "Error: $CONFIG_FILE has an empty EXTENSIONS list." >&2
+    exit 1
+fi
+
+# Seed the exclude-patterns file alongside the main config on first run.
+EXCLUDE_PATH="$CONFIG_DIR/${EXCLUDE_FILE:-exclude_paths.txt}"
+if [[ ! -f "$EXCLUDE_PATH" ]]; then
+    cp "$SCRIPT_DIR/exclude_paths.txt.example" "$EXCLUDE_PATH"
+fi
+
+EXCLUDE_PATTERNS=()
+while IFS= read -r line; do
+    [[ -z "$line" || "$line" == \#* ]] && continue
+    EXCLUDE_PATTERNS+=("$line")
+done < "$EXCLUDE_PATH"
 
 # Fall back to the configured default if -d/--days wasn't given
 DAYS_OLD="${DAYS_OLD:-$DEFAULT_DAYS_OLD}"
@@ -131,12 +176,22 @@ if [[ ! -d "$MUSIC_DIR" ]]; then
 fi
 
 PLAYLIST_FILE="$PLAYLIST_DIR/${PLAYLIST_TITLE}.m3u"
-# Write to a temp file first so a failed/interrupted run never touches an
+# Write to temp files first so a failed/interrupted run never touches an
 # existing good playlist; only replace it once we know the run succeeded.
+# SIZE_TMP holds the -n/--limit or -r/--random result before it replaces
+# TMP_FILE's full candidate list.
 TMP_FILE="$(mktemp "${PLAYLIST_FILE}.XXXXXX")"
-trap 'rm -f "$TMP_FILE"' EXIT
+SIZE_TMP="$(mktemp "${PLAYLIST_FILE}.XXXXXX")"
+trap 'rm -f "$TMP_FILE" "$SIZE_TMP"' EXIT
 
-count=0
+# Build the `-iname "*.ext" -o -iname "*.ext" ...` clause from EXTENSIONS
+# so the matched formats are configurable instead of hardcoded.
+read -ra EXT_LIST <<< "$EXTENSIONS"
+FIND_NAME_ARGS=()
+for ext in "${EXT_LIST[@]}"; do
+    [[ ${#FIND_NAME_ARGS[@]} -gt 0 ]] && FIND_NAME_ARGS+=(-o)
+    FIND_NAME_ARGS+=(-iname "*.${ext}")
+done
 
 # Strip the MUSIC_DIR prefix (and any leading slash) from each match so
 # paths in the playlist are relative to MPD's music_directory. Using bash
@@ -146,21 +201,39 @@ count=0
 #
 # `-printf '%T@ %p\0'` prefixes each match with its mtime (epoch seconds) so
 # `sort -z -rn -k1,1` can order the NUL-delimited records newest first
-# without breaking on paths that contain spaces or newlines. The loop keeps
-# reading every record even past -n/--limit (rather than breaking early) so
-# `find`/`sort` upstream never see a broken pipe under `pipefail`.
-if ! find -L "$MUSIC_DIR" -type f -mtime "-${DAYS_OLD}" \( -iname "*.mp3" -o -iname "*.m4a" -o -iname "*.flac" -o -iname "*.ogg" \) -printf '%T@ %p\0' |
+# without breaking on paths that contain spaces or newlines. TMP_FILE gets
+# every matching candidate; -n/--limit or -r/--random is applied afterwards
+# as a separate pass over the full list (see below).
+if ! find -L "$MUSIC_DIR" -type f -mtime "-${DAYS_OLD}" \( "${FIND_NAME_ARGS[@]}" \) -printf '%T@ %p\0' |
     sort -z -rn -k1,1 |
     while IFS=' ' read -r -d '' _mtime file; do
-        if [[ -z "$LIMIT" ]] || (( count < LIMIT )); then
-            relative="${file#"$MUSIC_DIR"}"
-            relative="${relative#/}"
-            printf '%s\n' "$relative"
-        fi
-        count=$((count + 1))
+        relative="${file#"$MUSIC_DIR"}"
+        relative="${relative#/}"
+
+        excluded=false
+        for pattern in "${EXCLUDE_PATTERNS[@]}"; do
+            if [[ "$relative" == $pattern ]]; then
+                excluded=true
+                break
+            fi
+        done
+        [[ "$excluded" == true ]] && continue
+
+        printf '%s\n' "$relative"
     done > "$TMP_FILE"; then
     echo "Error: Failed to create playlist. Possible permission issue." >&2
     exit 1
+fi
+
+# Apply -r/--random (a random sample of the pool) or -n/--limit (the
+# newest N, which TMP_FILE is already sorted as) against the full
+# candidate list gathered above.
+if [[ -n "$RANDOM_COUNT" ]]; then
+    shuf -n "$RANDOM_COUNT" "$TMP_FILE" > "$SIZE_TMP"
+    mv "$SIZE_TMP" "$TMP_FILE"
+elif [[ -n "$LIMIT" ]]; then
+    head -n "$LIMIT" "$TMP_FILE" > "$SIZE_TMP"
+    mv "$SIZE_TMP" "$TMP_FILE"
 fi
 
 # Handle empty results: leave the temp file behind for the trap to clean up,


### PR DESCRIPTION
## Summary
- `EXTENSIONS` in the config now controls which file extensions are scanned (default `mp3 m4a flac ogg`), replacing the hardcoded list. Empty `EXTENSIONS` is rejected with a clear error.
- Adds `exclude_paths.txt` (seeded from `exclude_paths.txt.example`), listing glob patterns relative to `MUSIC_DIR` to skip -- mirrors the exclude-list convention already used by `mpd-smart-shuffle` elsewhere in this repo.
- Adds `-r/--random N`, which picks N songs at random (via `shuf`) from the recent-tracks pool instead of the newest N. Mutually exclusive with `-n/--limit`; both are applied as a post-pass over the full candidate list rather than during the scan, which also simplified the -n/--limit implementation (no more inline counter).
- Registers `exclude_paths.txt.example` as a companion file in `install.sh`.

## Test plan
- [x] `bash -n mpd-recent-tracks/mpd-recent-tracks.sh` and `bash -n install.sh` both pass.
- [x] Smoke-tested: EXTENSIONS filtering (including enabling `wav`), empty-EXTENSIONS error, exclude patterns (`Podcasts/*`, `*/Live/*`) removing matching files without consuming `-n`/`-r` slots, `-r` producing a varying random sample across runs while `-n` stays deterministic, `-n`/`-r` mutual-exclusion error, invalid `-r` value error, and a combined run (exclude + extensions + `-r` + `-q` + `-l -p` against a stubbed `mpc`).
- [ ] Manual test against a real `mpd`/`mpc` install (not available in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)