### PR TITLE
Add .gitignore for mpc-fade's live config file

### DIFF
--- a/mpc-fade/.gitignore
+++ b/mpc-fade/.gitignore
@@ -1,0 +1,2 @@
+# Ignore a locally-created live config; only mpc-fade.conf.example is tracked
+mpc-fade.conf


### PR DESCRIPTION
## Summary
- Every other tool that ships a `.conf.example` template (lastfm-love, mpd-recent-tracks, music_queue_manager, rm-artists-playlist, rm-duplicates-playlist, mpd-queue-shuffle, mpdsimilar, mpd-radio-tray) has its own `.gitignore` protecting the seeded live config file. `mpc-fade` was the one exception, missed when it was added in #80.

## Test plan
- [x] `git status` confirms `mpc-fade.conf` (if created locally) is now ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)