### PR TITLE
Add playpause script

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Collection of scripts related to mpd & mpc.
 | **[music_queue_manager](./music_queue_manager/)** | Manages song ratings and "bad" flags via MPD stickers: rate on a 5- or 10-point scale, flag/unflag broken songs, remove or jump to a random/top-rated song, and list or rescale ratings. |
 | **[mpd-recent-tracks](./mpd-recent-tracks/)** | Generates an M3U playlist (newest first) of music files added or modified in the last N days, optionally capped in size and auto-loaded into MPD, paused or playing. |
 | **[mpc-fade](./mpc-fade/)** | Fades MPD playback volume smoothly to a target level over a duration, or fades out/toggles play-pause/fades back in, using either MPD's own volume or a PulseAudio sink-input stream. |
+| **[playpause](./playpause/)** | Prints the currently playing MPD track prefixed with a play/pause symbol, for use in a status bar (polybar, i3blocks, xmobar, etc). |
 
 ### Prerequisites
 Listed in each script's README.md.
@@ -79,6 +80,7 @@ Contributions are welcome!
 
 - The original setup of this repository is by [William Jacoby](https://github.com/bonelifer). For a full list of all authors and contributors, see [the contributors page](https://github.com/bonelifer/mpd-scripts/contributors).
 - [mpc-fade](./mpc-fade/) combines and builds on gists by [koppi](https://gist.github.com/koppi/60b9d1f14b0af2bdde1e49b9c225649d) and [Pablo1107](https://gist.github.com/Pablo1107/1d61cfa39e683289d96301230bf88fa5).
+- [playpause](./playpause/) is based on a [gist](https://gist.github.com/fernandotakai/8138704) by [fernandotakai](https://gist.github.com/fernandotakai).
 - Documentation updates assisted by [Claude](https://www.anthropic.com/claude).
 
 ## License

--- a/install.sh
+++ b/install.sh
@@ -290,6 +290,7 @@ SIMPLE_SCRIPTS=(
     "mpdsimilar|mpdsimilar.sh|mpdsimilar.conf.example"
     "mpd-tray-icon|mpd-tray-icon.py|"
     "music_queue_manager|music_queue_manager.sh|music_queue_manager.conf.example"
+    "playpause|playpause.sh|playpause.conf.example"
     "rm-artists-playlist|rm-artists-playlist.sh|rm-artists-playlist.conf.example"
     "rm-duplicates-playlist|rm-duplicates-playlist.sh|rm-duplicates-playlist.conf.example"
     "somafm|soma_fm_playlist_fetcher.py|"

--- a/playpause/.gitignore
+++ b/playpause/.gitignore
@@ -1,0 +1,2 @@
+# Ignore a locally-created live config; only playpause.conf.example is tracked
+playpause.conf

--- a/playpause/README.md
+++ b/playpause/README.md
@@ -1,0 +1,50 @@
+# mpd-scripts - playpause
+
+Prints the currently playing MPD track, prefixed with a play/pause symbol, for use in a status bar (polybar, i3blocks, xmobar, etc).
+
+## Features
+
+- **Play/pause/stop indicator**: prints `► <title>` while MPD is playing, `∎∎ <title>` while paused, or just `■` when stopped (MPD reports no current-track line in that state, so no title is shown).
+- **Configurable symbols**: the three symbols above can be overridden in the config file.
+- **Title truncation**: `-l`/`--max-len LEN` truncates a long title to `LEN` characters with a trailing ellipsis, so it doesn't overflow a fixed-width status bar module. Off by default; can be made the default via the config file.
+- **Empty-title fallback**: if `mpc` reports a blank current-track line (e.g. some internet radio streams with no tags), prints a configurable placeholder instead of a bare symbol with trailing whitespace.
+- **Silent failure**: prints nothing if `mpc` fails (e.g. MPD isn't running), instead of cluttering the status bar with an error.
+
+## Requirements
+
+- `mpc`
+- Bash 4 or later
+
+## Configuration
+
+Optional. `SYMBOL_PLAYING`, `SYMBOL_PAUSED`, `SYMBOL_STOPPED`, `MAX_LEN`, and `FALLBACK_TITLE` live in `~/.config/mpd-scripts/playpause/playpause.conf`, seeded from [`playpause.conf.example`](./playpause.conf.example). Without a config file, the built-in defaults shown in the example apply. Edit the copy in `~/.config/mpd-scripts/playpause/`, not the template.
+
+## Usage
+
+```bash
+playpause.sh [-l LEN] [-h]
+```
+
+- `-l`, `--max-len LEN`: truncate the title to `LEN` characters, with an ellipsis when cut short (default: no limit, or `MAX_LEN` from the config file if set).
+- `-h`, `--help`: show usage and exit.
+
+Typical usage is wiring it up as a polybar/i3blocks custom script that polls on an interval or refreshes on an MPD event.
+
+Example polybar module:
+
+```ini
+[module/mpd-playpause]
+type = custom/script
+exec = ~/bin/music/playpause.sh --max-len 40
+interval = 2
+```
+
+## Acknowledgments
+
+Based on a [gist](https://gist.github.com/fernandotakai/8138704) by [fernandotakai](https://gist.github.com/fernandotakai).
+
+## License
+
+This project is licensed under the **GNU General Public License v3.0**.
+
+See [LICENSE](../LICENSE) for more information.

--- a/playpause/playpause.conf.example
+++ b/playpause/playpause.conf.example
@@ -1,0 +1,17 @@
+# Symbol printed before the title while MPD is playing.
+SYMBOL_PLAYING="►"
+
+# Symbol printed before the title while MPD is paused.
+SYMBOL_PAUSED="∎∎"
+
+# Symbol printed alone (no title) while MPD is stopped.
+SYMBOL_STOPPED="■"
+
+# Truncate the title to this many characters, appending an ellipsis when
+# it's cut short. Overridden by -l/--max-len on the command line.
+# 0 = no truncation.
+MAX_LEN=0
+
+# Title shown when MPD reports an empty current-track line (e.g. some
+# internet radio streams with no tags).
+FALLBACK_TITLE="(unknown track)"

--- a/playpause/playpause.sh
+++ b/playpause/playpause.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/bash
+#
+# playpause.sh
+#
+# Prints the currently playing/paused MPD track for use in a status bar
+# (e.g. polybar, i3blocks), prefixed with a play/pause/stop symbol.
+#
+# Usage:
+#   playpause.sh [-l LEN] [-h]
+#
+# Options:
+#   -l, --max-len LEN   Truncate the title to LEN characters, appending an
+#                       ellipsis when it's cut short (default: 0, meaning
+#                       no truncation, or MAX_LEN from the config file
+#                       below if set).
+#   -h, --help          Show this help and exit.
+#
+# Output:
+#   "<symbol> <title>" on stdout when a track is playing or paused; just
+#   "<symbol>" when MPD is stopped, since `mpc` reports no current-track
+#   line in that state. Symbol is "►" playing, "∎∎" paused, "■" stopped,
+#   or SYMBOL_PLAYING/SYMBOL_PAUSED/SYMBOL_STOPPED from the config file
+#   below if set. Prints nothing if `mpc` fails (e.g. MPD is not running).
+#
+# Configuration:
+#   SYMBOL_PLAYING, SYMBOL_PAUSED, SYMBOL_STOPPED, MAX_LEN, and
+#   FALLBACK_TITLE live in ~/.config/mpd-scripts/playpause/playpause.conf,
+#   seeded from playpause.conf.example (shipped alongside this script).
+#   All optional -- without a config file, the built-in defaults above
+#   apply.
+
+set -euo pipefail
+
+PROGRAM_NAME="$(basename "$0")"
+
+# Aborts with an error if a required command isn't on PATH.
+require_cmd() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo >&2 "$PROGRAM_NAME: ERROR: command '$1' not found in PATH."
+        exit 1
+    fi
+}
+
+require_cmd mpc
+
+# SYMBOL_*/MAX_LEN/FALLBACK_TITLE are all optional -- if the config file
+# doesn't exist yet, everything just falls back to the defaults set here.
+CONFIG_DIR="$HOME/.config/mpd-scripts/playpause"
+CONFIG_FILE="$CONFIG_DIR/playpause.conf"
+
+SYMBOL_PLAYING="►"
+SYMBOL_PAUSED="∎∎"
+SYMBOL_STOPPED="■"
+MAX_LEN=0
+FALLBACK_TITLE="(unknown track)"
+if [[ -f "$CONFIG_FILE" ]]; then
+    # shellcheck source=playpause.conf.example
+    source "$CONFIG_FILE"
+fi
+
+display_help() {
+    cat <<HELP
+Usage:
+  $PROGRAM_NAME [-l LEN] [-h]
+
+Options:
+  -l, --max-len LEN   Truncate the title to LEN characters, with an ellipsis
+                     when cut short (default: $MAX_LEN, meaning no limit,
+                     or MAX_LEN from $CONFIG_FILE if set).
+  -h, --help          Show this help and exit.
+HELP
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -l|--max-len) MAX_LEN="$2"; shift 2 ;;
+        -h|--help) display_help; exit 0 ;;
+        -*) echo >&2 "$PROGRAM_NAME: ERROR: unknown option '$1'"; display_help; exit 1 ;;
+        *) echo >&2 "$PROGRAM_NAME: ERROR: unexpected argument '$1'"; display_help; exit 1 ;;
+    esac
+done
+
+# Truncates $1 to $MAX_LEN characters, appending an ellipsis if it's cut
+# short. MAX_LEN=0 (the default) means no truncation.
+truncate_title() {
+    local title="$1"
+    if (( MAX_LEN > 0 )) && (( ${#title} > MAX_LEN )); then
+        echo "${title:0:MAX_LEN}…"
+    else
+        echo "$title"
+    fi
+}
+
+mpc_output=$(mpc) || exit
+status_line=$(grep -E '^\[(playing|paused|stopped)\]' <<< "$mpc_output" || true)
+status=$(cut -f 1 -d ' ' <<< "$status_line")
+
+case "$status" in
+    "[playing]"|"[paused]")
+        title=$(head -n 1 <<< "$mpc_output")
+        [[ -z "$title" ]] && title="$FALLBACK_TITLE"
+        title=$(truncate_title "$title")
+        if [[ "$status" == "[playing]" ]]; then
+            echo "$SYMBOL_PLAYING $title"
+        else
+            echo "$SYMBOL_PAUSED $title"
+        fi
+        ;;
+    *)
+        echo "$SYMBOL_STOPPED"
+        ;;
+esac


### PR DESCRIPTION
## Summary
- Adds `playpause/`, a status-bar script that prints the currently playing/paused MPD track prefixed with a play/pause/stop symbol, based on a [gist by fernandotakai](https://gist.github.com/fernandotakai/8138704)
- Configurable symbols, `-l`/`--max-len` title truncation, and an empty-title fallback via `playpause.conf` (seeded from `playpause.conf.example`)
- Wires it into `install.sh`'s `SIMPLE_SCRIPTS` and adds it to the root README's script table and Acknowledgments

## Test plan
- [x] `bash -n` syntax check on `playpause.sh` and `install.sh`
- [x] Functional test against a stubbed `mpc`: playing (with truncation), paused, stopped, and empty-title fallback all produce expected output
- [x] `-h`/`--help` output reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)