### PR TITLE
Add mpdmark: bookmark playback positions in MPD

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Collection of scripts related to mpd & mpc.
 | **[mpd-tray-icon](./mpd-tray-icon/)** | A GTK3 tray icon showing the currently playing MPD track, with Play/Pause/Next/Previous controls. |
 | **[mpd-radio-tray](./mpd-radio-tray/)** | A PyQt5 system tray app for managing and playing categorized internet radio station URLs with MPD, similar to RadioTray-NG. |
 | **[music_queue_manager](./music_queue_manager/)** | Manages song ratings and "bad" flags via MPD stickers: rate on a 5- or 10-point scale, flag/unflag broken songs, remove or jump to a random/top-rated song, and list or rescale ratings. |
+| **[mpdmark](./mpdmark/)** | Bookmark playback positions in MPD via stickers, with multiple named bookmarks per song, listing, loading, renaming, deleting, and pruning stale entries. |
 | **[mpd-recent-tracks](./mpd-recent-tracks/)** | Generates an M3U playlist (newest first) of music files added or modified in the last N days, optionally capped in size and auto-loaded into MPD, paused or playing. |
 | **[mpc-fade](./mpc-fade/)** | Fades MPD playback volume smoothly to a target level over a duration, or fades out/toggles play-pause/fades back in, using either MPD's own volume or a PulseAudio sink-input stream. |
 | **[playpause](./playpause/)** | Prints the currently playing MPD track prefixed with a play/pause symbol, for use in a status bar (polybar, i3blocks, xmobar, etc). |
@@ -81,6 +82,7 @@ Contributions are welcome!
 - The original setup of this repository is by [William Jacoby](https://github.com/bonelifer). For a full list of all authors and contributors, see [the contributors page](https://github.com/bonelifer/mpd-scripts/contributors).
 - [mpc-fade](./mpc-fade/) combines and builds on gists by [koppi](https://gist.github.com/koppi/60b9d1f14b0af2bdde1e49b9c225649d) and [Pablo1107](https://gist.github.com/Pablo1107/1d61cfa39e683289d96301230bf88fa5).
 - [playpause](./playpause/) is based on a [gist](https://gist.github.com/fernandotakai/8138704) by [fernandotakai](https://gist.github.com/fernandotakai).
+- [mpdmark](./mpdmark/) is based on `mpdmark` from [Mic92/mpdtools](https://github.com/Mic92/mpdtools).
 - Documentation updates assisted by [Claude](https://www.anthropic.com/claude).
 
 ## License

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,1 +1,3 @@
 # mpd-scripts - TODO
+
+- **Auto-bookmark-on-pause**: automatically save a bookmark when playback pauses/stops, so `mpdmark load` becomes a generic "resume where you left off." This is daemon-shaped work (listens for MPD pause/stop events, like `mpd_rewind_daemon`) rather than an on-demand CLI action, so it belongs in its own project directory (e.g. `mpd_autobookmark_daemon/`) instead of inside `mpdmark/`, sharing `mpdmark`'s JSON bookmark-sticker format so both tools can read/write the same bookmarks.

--- a/install.sh
+++ b/install.sh
@@ -289,6 +289,7 @@ SIMPLE_SCRIPTS=(
     "mpd-recent-tracks|mpd-recent-tracks.sh|mpd-recent-tracks.conf.example exclude_paths.txt.example"
     "mpdsimilar|mpdsimilar.sh|mpdsimilar.conf.example"
     "mpd-tray-icon|mpd-tray-icon.py|"
+    "mpdmark|mpdmark.py|mpdmark.conf.example"
     "music_queue_manager|music_queue_manager.sh|music_queue_manager.conf.example"
     "playpause|playpause.sh|playpause.conf.example"
     "rm-artists-playlist|rm-artists-playlist.sh|rm-artists-playlist.conf.example"

--- a/mpdmark/README.md
+++ b/mpdmark/README.md
@@ -1,0 +1,96 @@
+# mpdmark
+
+Bookmark playback positions in MPD, keyed by name, using the sticker database.
+
+## Features
+
+- **Named bookmarks**: save more than one bookmark per song (e.g. `intro`, `chapter5` on the same audiobook file) instead of a single implicit position.
+- **List**: view every bookmark across the whole library, numbered for use with `load`/`del`/`rename`.
+- **Load**: queue (if needed) and seek to any saved bookmark, even for a song that isn't currently playing.
+- **Delete**: remove a single bookmark, by list number or by `--song`/`--name`.
+- **Rename**: change a bookmark's name without losing its saved position.
+- **Prune**: clean up bookmarks left behind on songs no longer in the library.
+- **Stable addressing**: `del`/`load`/`rename` accept `--song`/`--name` as an alternative to the list index, which stays correct even if the bookmark set has changed since you last ran `list`.
+
+## Requirements
+
+- Python 3
+- [`python-mpd2`](https://pypi.org/project/python-mpd2/) (`pip install --user python-mpd2`)
+- MPD 0.15 or later with sticker support enabled (`sticker_file` set in `mpd.conf`)
+
+## Configuration
+
+On first run, a config file is created at
+`~/.config/mpd-scripts/mpdmark/mpdmark.conf`, seeded from
+[`mpdmark.conf.example`](./mpdmark.conf.example). Edit the copy there, not
+the template.
+
+| Setting | Description | Default |
+| --- | --- | --- |
+| `mpd_host` | MPD server hostname/IP | `localhost` |
+| `mpd_port` | MPD server port | `6600` |
+| `mpd_password` | MPD password, if required (leave blank if none) | *(blank)* |
+
+`-H`/`--host`, `-P`/`--port`, and `-a`/`--password` override the config file for a single invocation.
+
+## Usage
+
+```
+mpdmark.py [-H HOST] [-P PORT] [-a PASSWORD] {list,del,save,load,rename,prune} ...
+```
+
+| Command | Description |
+| --- | --- |
+| `list` | List all bookmarks, numbered. |
+| `save [-n NAME]` | Save the current song's playback position under `NAME` (default: `default`). |
+| `load [index]` \| `load -s SONG -n NAME` | Queue (if needed) and jump to a bookmark, by list index (default: `1`) or by song + name. |
+| `del [index]` \| `del -s SONG -n NAME` | Delete a bookmark, by list index (default: `1`) or by song + name. |
+| `rename [index] -t NEW_NAME` \| `rename -s SONG -n NAME -t NEW_NAME` | Rename a bookmark, keeping its saved position. |
+| `prune` | Remove bookmarks for songs no longer in the library. |
+
+`-s`/`--song` and `-n`/`--name` must be used together, and can't be combined with an index — they're an alternative addressing mode, not a filter.
+
+### Examples
+
+```bash
+# Bookmark the current position as "chapter5"
+mpdmark.py save -n chapter5
+
+# Bookmark the current position with the default name
+mpdmark.py save
+
+# See everything you've bookmarked
+mpdmark.py list
+
+# Jump back to bookmark #2
+mpdmark.py load 2
+
+# Jump back to a bookmark by song + name instead of list index
+mpdmark.py load -s "Audiobooks/Dune/01.mp3" -n chapter5
+
+# Remove bookmark #2
+mpdmark.py del 2
+
+# Rename a bookmark
+mpdmark.py rename -s "Audiobooks/Dune/01.mp3" -n chapter5 -t "part-one"
+
+# Clean up bookmarks for songs that were deleted from the library
+mpdmark.py prune
+
+# Connect to a remote MPD server
+mpdmark.py -H mpd.example.com -P 6600 list
+```
+
+## How it works
+
+Each song's bookmarks are stored as a single JSON-encoded `bookmark` sticker (e.g. `{"intro": 12.0, "chapter5": 941.5}`), so listing every bookmark in the library only takes one `sticker find` call regardless of how many songs or names are involved. `list`'s numbering reflects the current bookmark set sorted by file then name, so it can shift if bookmarks are added or removed between calls; use `--song`/`--name` instead of an index for `del`/`load`/`rename` if the call isn't immediately following a `list`. MPD doesn't clean up stickers when a file disappears from the library, so run `prune` occasionally (or after a library reorganization) to clear out bookmarks left on deleted or moved files.
+
+## Acknowledgments
+
+Based on `mpdmark` from [Mic92/mpdtools](https://github.com/Mic92/mpdtools), ported to Python 3 and the maintained `python-mpd2` library, with named/multiple bookmarks per song added on top of the original single-bookmark-per-song design.
+
+## License
+
+This project is licensed under the **GNU General Public License v3.0**.
+
+See [LICENSE](../LICENSE) for more information.

--- a/mpdmark/mpdmark.conf.example
+++ b/mpdmark/mpdmark.conf.example
@@ -1,0 +1,14 @@
+# mpdmark configuration
+#
+# Copied to ~/.config/mpd-scripts/mpdmark/mpdmark.conf on first run if that
+# file doesn't already exist. Edit the copy there, not this template.
+
+[mpdmark]
+
+# MPD connection details. Can be overridden per invocation with
+# -H/--host, -P/--port, -a/--password.
+mpd_host = localhost
+mpd_port = 6600
+
+# Leave blank unless your MPD requires a password.
+mpd_password =

--- a/mpdmark/mpdmark.py
+++ b/mpdmark/mpdmark.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+
+"""
+mpdmark
+
+Bookmark playback positions in MPD using the sticker database (requires
+MPD >= 0.15 with sticker support enabled).
+
+Each song can hold multiple named bookmarks, stored as a single JSON-encoded
+"bookmark" sticker per song (e.g. {"intro": 12.0, "chapter5": 941.5}), so one
+MPD sticker_find call is enough to list every bookmark in the library. The
+`list` command prints a flat, numbered view across all songs/names; `load`,
+`del`, and `rename` address entries by that number, or by an explicit
+--song/--name pair that stays valid even if the numbering has shifted.
+`prune` removes bookmarks left behind on songs no longer in the library.
+
+Connection settings (host/port/password) come from
+~/.config/mpd-scripts/mpdmark/mpdmark.conf, seeded from mpdmark.conf.example
+on first run; --host/--port/--password on the command line override the
+config file for a single invocation.
+"""
+
+import argparse
+import configparser
+import json
+import os
+import sys
+from os.path import basename
+
+from mpd import MPDClient, CommandError
+from socket import error as SocketError
+
+STICKER_NAME = "bookmark"
+DEFAULT_BOOKMARK_NAME = "default"
+
+CONFIG_DIR = os.path.join(os.path.expanduser("~"), ".config", "mpd-scripts", "mpdmark")
+CONFIG_FILE = os.path.join(CONFIG_DIR, "mpdmark.conf")
+
+
+def load_config() -> configparser.SectionProxy:
+    """Load ~/.config/mpd-scripts/mpdmark/mpdmark.conf, seeding it from the
+    mpdmark.conf.example template shipped alongside this script on first run.
+
+    Returns:
+        configparser.SectionProxy: the "mpdmark" section.
+    """
+    if not os.path.exists(CONFIG_FILE):
+        os.makedirs(CONFIG_DIR, mode=0o700, exist_ok=True)
+        template = os.path.join(os.path.dirname(os.path.abspath(__file__)), "mpdmark.conf.example")
+        with open(template) as src, open(CONFIG_FILE, "w") as dst:
+            dst.write(src.read())
+        os.chmod(CONFIG_FILE, 0o600)  # May contain an MPD password
+
+    config = configparser.ConfigParser()
+    config.read(CONFIG_FILE)
+    return config["mpdmark"]
+
+
+def die(msg: str) -> None:
+    """Print an error message to stderr and exit with status 1."""
+    sys.stderr.write(msg)
+    sys.stderr.write("\n")
+    sys.exit(1)
+
+
+def format_time(seconds: float) -> str:
+    """Format a duration in seconds as MM:SS, or HH:MM:SS if an hour or more."""
+    seconds = int(seconds)
+    hours, seconds = divmod(seconds, 3600)
+    minutes, seconds = divmod(seconds, 60)
+    if hours == 0:
+        return f"{minutes:02d}:{seconds:02d}"
+    return f"{hours:02d}:{minutes:02d}:{seconds:02d}"
+
+
+def get_elapsed(status: dict) -> float:
+    """Return the current playback position in seconds from MPD's "elapsed" status field."""
+    return float(status["elapsed"])
+
+
+class App:
+    def get_song_bookmarks(self, uri: str) -> dict:
+        """Return the {name: elapsed_seconds} bookmark dict stored on a song, or {} if none."""
+        try:
+            raw = self._client.sticker_get("song", uri, STICKER_NAME)
+        except CommandError:
+            return {}
+        try:
+            return json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            return {}
+
+    def set_song_bookmarks(self, uri: str, bookmarks: dict) -> None:
+        """Store (or, if empty, delete) a song's bookmark dict."""
+        if bookmarks:
+            self._client.sticker_set("song", uri, STICKER_NAME, json.dumps(bookmarks))
+        else:
+            try:
+                self._client.sticker_delete("song", uri, STICKER_NAME)
+            except CommandError:
+                pass
+
+    def get_all_bookmarks(self) -> list[tuple[str, str, float]]:
+        """Return every (uri, name, elapsed_seconds) bookmark in the library.
+
+        Sorted by uri then name so the numbering `list` prints stays stable
+        between calls as long as the bookmark set itself hasn't changed.
+        """
+        entries = []
+        for row in self._client.sticker_find("song", "/", STICKER_NAME):
+            uri = row["file"]
+            _, _, raw_value = row["sticker"].partition("=")
+            try:
+                bookmarks = json.loads(raw_value)
+            except (json.JSONDecodeError, TypeError):
+                continue
+            for name, elapsed in bookmarks.items():
+                entries.append((uri, name, float(elapsed)))
+        entries.sort(key=lambda entry: (entry[0], entry[1]))
+        return entries
+
+    def list_bookmarks(self, args: argparse.Namespace) -> None:
+        """Print every bookmark in the library, numbered for use with load/del."""
+        for i, (uri, name, elapsed) in enumerate(self.get_all_bookmarks(), start=1):
+            info = self._client.listallinfo(uri)[0]
+            total = format_time(float(info["time"]))
+            title = info.get("title", basename(uri))
+            print(f"({i}) [{name}] {format_time(elapsed)}/{total} {title}")
+
+    def resolve_target(self, args: argparse.Namespace) -> tuple[str, str, float]:
+        """Resolve a (uri, name, elapsed) bookmark from either a list index or
+        an explicit --song/--name pair.
+
+        --song/--name address a bookmark directly, which stays correct even
+        if other bookmarks are added or removed in between calls -- unlike
+        an index, which is only valid against the same `list` output it came
+        from. Dies with a usage error if the argument combination is
+        invalid, or if nothing matches.
+        """
+        if args.song is not None or args.name is not None:
+            if args.song is None or args.name is None:
+                die("--song and --name must be used together")
+            if args.index is not None:
+                die("Cannot combine an index with --song/--name")
+            bookmarks = self.get_song_bookmarks(args.song)
+            if args.name not in bookmarks:
+                die(f"No bookmark named {args.name!r} on {args.song!r}")
+            return args.song, args.name, float(bookmarks[args.name])
+
+        entries = self.get_all_bookmarks()
+        index = args.index if args.index is not None else 1
+        if not (1 <= index <= len(entries)):
+            die("Invalid bookmark index")
+        return entries[index - 1]
+
+    def delete_bookmark(self, args: argparse.Namespace) -> None:
+        """Delete the resolved bookmark."""
+        uri, name, _ = self.resolve_target(args)
+        bookmarks = self.get_song_bookmarks(uri)
+        bookmarks.pop(name, None)
+        self.set_song_bookmarks(uri, bookmarks)
+        print(f"Deleted bookmark {name!r} on {uri}")
+
+    def save_bookmark(self, args: argparse.Namespace) -> None:
+        """Save the current playback position under the given name for the current song."""
+        current = self._client.currentsong()
+        if not current:
+            die("No song is currently playing.")
+        status = self._client.status()
+        elapsed = get_elapsed(status)
+
+        bookmarks = self.get_song_bookmarks(current["file"])
+        bookmarks[args.name] = elapsed
+        self.set_song_bookmarks(current["file"], bookmarks)
+
+    def rename_bookmark(self, args: argparse.Namespace) -> None:
+        """Rename the resolved bookmark, keeping its saved position."""
+        uri, name, elapsed = self.resolve_target(args)
+        if args.to == name:
+            return
+        bookmarks = self.get_song_bookmarks(uri)
+        if args.to in bookmarks:
+            die(f"A bookmark named {args.to!r} already exists on {uri!r}")
+        del bookmarks[name]
+        bookmarks[args.to] = elapsed
+        self.set_song_bookmarks(uri, bookmarks)
+        print(f"Renamed bookmark {name!r} to {args.to!r} on {uri}")
+
+    def load_bookmark(self, args: argparse.Namespace) -> None:
+        """Queue (if needed) and seek to the resolved bookmark."""
+        uri, _, elapsed = self.resolve_target(args)
+
+        playlist = self._client.playlistid()
+        songid = None
+        for song in playlist:
+            if song.get("file") == uri:
+                songid = song["id"]
+                break
+        if songid is None:
+            songid = self._client.addid(uri)
+        self._client.seekid(songid, elapsed)
+        self._client.playid(songid)
+
+    def prune_bookmarks(self, args: argparse.Namespace) -> None:
+        """Remove bookmarks for songs no longer in the library.
+
+        MPD doesn't clean up stickers when a file disappears from the
+        library, so bookmarks for deleted/moved files would otherwise
+        accumulate silently.
+        """
+        library_uris = {obj["file"] for obj in self._client.listall() if "file" in obj}
+        stale_uris = {uri for uri, _, _ in self.get_all_bookmarks()} - library_uris
+        for uri in stale_uris:
+            self.set_song_bookmarks(uri, {})
+            print(f"Pruned bookmarks for missing song: {uri}")
+        if not stale_uris:
+            print("No stale bookmarks found.")
+
+    def parse_args(self) -> argparse.Namespace:
+        parser = argparse.ArgumentParser(description="Bookmark song positions in MPD")
+        parser.add_argument("-H", "--host", help="Host address to connect to. Overrides mpdmark.conf.", default=None, type=str)
+        parser.add_argument("-P", "--port", help="Port to connect to. Overrides mpdmark.conf.", default=None, type=int)
+        parser.add_argument("-a", "--password", help="Password to authenticate with. Overrides mpdmark.conf.", default=None, type=str)
+        sub_parser = parser.add_subparsers(dest="command", required=True)
+
+        list_parser = sub_parser.add_parser("list", help="list all bookmarks")
+        list_parser.set_defaults(func=self.list_bookmarks)
+
+        del_parser = sub_parser.add_parser("del", help="delete a bookmark")
+        del_parser.set_defaults(func=self.delete_bookmark)
+        self._add_target_arguments(del_parser)
+
+        save_parser = sub_parser.add_parser("save", help="save position of current song")
+        save_parser.set_defaults(func=self.save_bookmark)
+        save_parser.add_argument("-n", "--name", type=str, default=DEFAULT_BOOKMARK_NAME, help="Name for this bookmark")
+
+        load_parser = sub_parser.add_parser("load", help="load a bookmark")
+        load_parser.set_defaults(func=self.load_bookmark)
+        self._add_target_arguments(load_parser)
+
+        rename_parser = sub_parser.add_parser("rename", help="rename a bookmark")
+        rename_parser.set_defaults(func=self.rename_bookmark)
+        self._add_target_arguments(rename_parser)
+        rename_parser.add_argument("-t", "--to", type=str, required=True, help="New name for the bookmark")
+
+        prune_parser = sub_parser.add_parser("prune", help="remove bookmarks for songs no longer in the library")
+        prune_parser.set_defaults(func=self.prune_bookmarks)
+
+        return parser.parse_args()
+
+    @staticmethod
+    def _add_target_arguments(subparser: argparse.ArgumentParser) -> None:
+        """Add the shared index / --song+--name addressing options used by
+        del, load, and rename (see resolve_target)."""
+        subparser.add_argument("index", type=int, nargs="?", default=None, help="Bookmark number from `list` (default: 1)")
+        subparser.add_argument("-s", "--song", type=str, default=None, help="Song URI; use with --name instead of index")
+        subparser.add_argument("-n", "--name", type=str, default=None, help="Bookmark name; use with --song instead of index")
+
+    def __init__(self) -> None:
+        args = self.parse_args()
+        config = load_config()
+        host = args.host or config.get("mpd_host", fallback="localhost")
+        port = args.port or config.getint("mpd_port", fallback=6600)
+        password = args.password or config.get("mpd_password", fallback="") or None
+
+        self._client = MPDClient()
+        try:
+            self._client.connect(host, port)
+        except SocketError as e:
+            die(f"Failed to connect to MPD server: {e}")
+        if password:
+            try:
+                self._client.password(password)
+            except CommandError as e:
+                die(f"Error authenticating with MPD: {e}")
+        if "sticker" not in self._client.commands():
+            die(
+                "MPD does not support stickers, or they aren't enabled.\n"
+                "This feature requires MPD 0.15 or later with sticker_file set.\n"
+                f"Your version is {self._client.mpd_version}."
+            )
+
+        args.func(args)
+
+        self._client.close()
+        self._client.disconnect()
+
+
+if __name__ == "__main__":
+    App()


### PR DESCRIPTION
## Summary
- Ports `mpdmark` from [Mic92/mpdtools](https://github.com/Mic92/mpdtools) to Python 3 and the maintained `python-mpd2` library
- Adds named/multiple bookmarks per song (JSON-encoded sticker), `rename`, `prune` (removes bookmarks for songs no longer in the library), and `--song`/`--name` addressing as a stable alternative to list indices
- Adds a config file (`~/.config/mpd-scripts/mpdmark/mpdmark.conf`, seeded from `mpdmark.conf.example`) for MPD connection settings, overridable per-invocation with `-H`/`-P`/`-a`
- Registers the tool in `install.sh`'s `SIMPLE_SCRIPTS` list and the top-level README's tools table/Acknowledgments
- Adds a TODO entry for a future separate auto-bookmark-on-pause daemon

## Test plan
- [x] `python3 -m py_compile mpdmark/mpdmark.py`
- [x] Exercised `list`/`save`/`load`/`del`/`rename`/`prune` and the `--song`/`--name` addressing against a mocked MPD client
- [x] Verified config file seeding, defaults, and `0600` permissions
- [x] Ran `mpdmark.py --help` and all subcommand `--help` output from the installed repo path

🤖 Generated with [Claude Code](https://claude.com/claude-code)