### PR TITLE
alarmpd --prune + new mpd-kb-control tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Collection of scripts related to mpd & mpc.
 | **[music_queue_manager](./music_queue_manager/)** | Manages song ratings and "bad" flags via MPD stickers: rate on a 5- or 10-point scale, flag/unflag broken songs, remove or jump to a random/top-rated song, and list or rescale ratings. |
 | **[mpdmark](./mpdmark/)** | Bookmark playback positions in MPD via stickers, with multiple named bookmarks per song, listing, loading, renaming, deleting, and pruning stale entries. |
 | **[alarmpd](./alarmpd/)** | Playlist-named alarm clock daemon: schedule alarms by creating/renaming an MPD playlist, with multi-day/named-group and one-shot forms, per-alarm volume caps, gentle fade-in with snooze, one-time skip, and collision detection. |
+| **[mpd-kb-control](./mpd-kb-control/)** | Dispatches multimedia-key presses (play/pause/next/prev/volume/mute) to MPD, plus consume/random/repeat/single mode toggles for a separate keypad, for binding in a window manager's keybindings. |
 | **[mpd-recent-tracks](./mpd-recent-tracks/)** | Generates an M3U playlist (newest first) of music files added or modified in the last N days, optionally capped in size and auto-loaded into MPD, paused or playing. |
 | **[mpc-fade](./mpc-fade/)** | Fades MPD playback volume smoothly to a target level over a duration, or fades out/toggles play-pause/fades back in, using either MPD's own volume or a PulseAudio sink-input stream. |
 | **[playpause](./playpause/)** | Prints the currently playing MPD track prefixed with a play/pause symbol, for use in a status bar (polybar, i3blocks, xmobar, etc). |
@@ -85,6 +86,7 @@ Contributions are welcome!
 - [playpause](./playpause/) is based on a [gist](https://gist.github.com/fernandotakai/8138704) by [fernandotakai](https://gist.github.com/fernandotakai).
 - [mpdmark](./mpdmark/) is based on `mpdmark` from [Mic92/mpdtools](https://github.com/Mic92/mpdtools).
 - [alarmpd](./alarmpd/) is based on [alarmpd](https://github.com/ingobecker/alarmpd) by Ingo Becker.
+- [mpd-kb-control](./mpd-kb-control/) is based on [mpd_kb_control](https://github.com/nogaems/mpd_kb_control) by nogaems.
 - Documentation updates assisted by [Claude](https://www.anthropic.com/claude).
 
 ## License

--- a/alarmpd/README.md
+++ b/alarmpd/README.md
@@ -13,6 +13,7 @@ A playlist-based alarm clock daemon for [MPD](https://www.musicpd.org/). Schedul
 * Refuses to guess: if two playlists resolve to the same exact time, neither is scheduled until the collision is resolved
 * Optional pre-/post-alarm shell hooks (lights, notifications, whatever)
 * A `--test` flag to fire an alarm immediately, for checking fade/volume/hook behavior without waiting
+* A `--prune` flag to delete expired one-shot alarm playlists, which otherwise just sit there unused forever
 * Reconnects to MPD automatically (with backoff) if it's down or restarts
 * alarmpd can run on a different machine than the one running MPD
 
@@ -68,7 +69,7 @@ Scheduling a new alarm is as easy as creating a playlist. The name determines wh
 | `Monday,Wednesday,Friday 7:30` | Recurs on each listed day |
 | `Weekdays 7:30` / `Weekends 9:00` / `Daily 6:45` | Built-in day groups |
 | `Monday 7:30 max=60` | Fades to 60% instead of `default_max_volume` |
-| `2026-08-12 7:30` | Fires once, on that date, then expires -- never reschedules |
+| `2026-08-12 7:30` | Fires once, on that date, then expires -- never reschedules (run `--prune` to delete it once it has) |
 | `!Monday 7:30` | Permanently disabled -- ignored entirely until renamed back |
 | `~Monday 7:30` | Skips just the next occurrence, then alarmpd renames it back to `Monday 7:30` automatically |
 
@@ -89,6 +90,12 @@ Test a playlist immediately, without waiting for its scheduled time:
 alarmpd.py --test "Monday 7:30"
 ```
 Works even if the name doesn't match the schedule grammar -- any existing playlist can be tested, falling back to `default_max_volume`.
+
+Delete expired one-shot alarm playlists (a past date never reschedules, so they'd otherwise accumulate unused):
+```bash
+alarmpd.py --prune
+```
+Recurring alarms, disabled (`!`) alarms, and future one-shot alarms are left alone. Safe to run periodically (e.g. from cron) or by hand.
 
 Stop the daemon (Option A / XDG autostart install):
 ```bash

--- a/alarmpd/alarmpd.py
+++ b/alarmpd/alarmpd.py
@@ -12,7 +12,9 @@ Recurring, one or more days:
     Weekdays 7:30          (Weekdays/Weekends/Daily are built-in groups)
     Monday 7:30 max=60      (fades to 60% instead of the configured default)
 
-One-shot, a specific date (never recurs, and expires once past):
+One-shot, a specific date (never recurs, and expires once past -- run
+this script with --prune to delete expired ones, since they otherwise
+just sit there unused):
     2026-08-12 7:30
     2026-08-12 7:30 max=60
 
@@ -397,6 +399,38 @@ class AlarmDaemon:
             self.fade_tick()
         self.log("Test alarm complete.")
 
+    def prune_expired(self, now: datetime) -> list:
+        """Delete stored playlists for one-shot alarms whose date has
+        already passed. Recurring alarms never expire and are left alone;
+        a schedule counts as expired the same way next_occurrence already
+        treats it (past one-shot dates never roll forward)."""
+        removed = []
+        for entry in self._client.listplaylists():
+            name = entry["playlist"]
+            schedule = parse_entry(name, self._default_max_volume)
+            if schedule is None or schedule.fire_date is None:
+                continue  # Not a one-shot alarm.
+            if schedule.next_occurrence(now) is None:
+                self._client.rm(name)
+                removed.append(name)
+        return removed
+
+    def run_prune(self) -> None:
+        """Connect, delete expired one-shot alarm playlists, print what was
+        removed, then return -- doesn't enter the daemon loop."""
+        try:
+            self.connect()
+        except (MPDConnectionError, OSError) as e:
+            print(f"Failed to connect to MPD: {e}", file=sys.stderr)
+            sys.exit(1)
+
+        removed = self.prune_expired(datetime.now().astimezone())
+        if removed:
+            for name in removed:
+                print(f"Pruned expired one-shot alarm: {name}")
+        else:
+            print("No expired one-shot alarms found.")
+
 
 def build_daemon(args: argparse.Namespace, config: configparser.SectionProxy) -> AlarmDaemon:
     return AlarmDaemon(
@@ -464,6 +498,8 @@ if __name__ == "__main__":
     parser.add_argument("-v", "--verbose", action="store_true", help="Run in the foreground with console logging")
     parser.add_argument("-t", "--test", metavar="PLAYLIST", default=None,
                          help="Immediately fire the named playlist as a test alarm, then exit")
+    parser.add_argument("--prune", action="store_true",
+                         help="Delete expired one-shot alarm playlists, then exit")
     cli_args = parser.parse_args()
 
     if cli_args.stop:
@@ -472,7 +508,9 @@ if __name__ == "__main__":
         check_permissions()  # AlarmDaemon.__init__ opens LOG_FILE under STATE_DIR right away
         cli_config = load_config()
         alarm_daemon = build_daemon(cli_args, cli_config)
-        if cli_args.test:
+        if cli_args.prune:
+            alarm_daemon.run_prune()
+        elif cli_args.test:
             alarm_daemon.fire_test(cli_args.test)
         elif cli_args.verbose:
             alarm_daemon.run()

--- a/install.sh
+++ b/install.sh
@@ -290,6 +290,7 @@ SIMPLE_SCRIPTS=(
     "mpd-recent-tracks|mpd-recent-tracks.sh|mpd-recent-tracks.conf.example exclude_paths.txt.example"
     "mpdsimilar|mpdsimilar.sh|mpdsimilar.conf.example"
     "mpd-tray-icon|mpd-tray-icon.py|"
+    "mpd-kb-control|mpd-kb-control.py|mpd-kb-control.conf.example"
     "mpdmark|mpdmark.py|mpdmark.conf.example"
     "music_queue_manager|music_queue_manager.sh|music_queue_manager.conf.example"
     "playpause|playpause.sh|playpause.conf.example"

--- a/mpd-kb-control/README.md
+++ b/mpd-kb-control/README.md
@@ -1,0 +1,128 @@
+# mpd-kb-control
+
+Dispatches multimedia-key presses to MPD -- bind `XF86AudioPlay`/`XF86AudioNext`/etc. in your window manager to this script, and it handles play/pause, track navigation, volume, mute, and MPD's consume/random/repeat/single playback modes.
+
+## Features
+
+* Correct play/pause/stopped detection via MPD's own `state` field, not text-scraped `mpc` output -- unlike the script this is based on, pressing play while MPD is stopped actually starts playback instead of silently doing nothing
+* Configurable volume step, with an optional ceiling so "raise" never pushes past a `max_volume` you set
+* Mute/unmute with automatic previous-volume save and restore
+* Toggle MPD's consume/random/repeat/single playback modes -- see below for binding these on a separate keypad, since they have no dedicated multimedia key
+* Optional desktop notifications on play/pause/volume changes (off by default) -- also shown on failure (connection lost, empty queue, wrong password, etc.) when enabled, since this runs from a keybinding with no visible terminal to print an error to
+* Mute/unmute is race-safe: two invocations firing close together (a double-tap, or an accidental duplicate keybinding) serialize instead of one clobbering the other's save
+
+## Requirements
+
+* Python 3
+* [`python-mpd2`](https://pypi.org/project/python-mpd2/)
+* MPD running and reachable (defaults to `localhost:6600`; see Configuration)
+* `notify-send` (optional, only used if `notify` is enabled in the config)
+
+## Usage
+
+```
+mpd-kb-control.py [-H HOST] [-P PORT] [-a PASSWORD] {play,next,prev,raise,lower,mute,consume,random,repeat,single}
+```
+
+| Command | Description |
+| --- | --- |
+| `play` | Toggle play/pause. Starts playback if MPD is currently stopped. |
+| `next` | Skip to the next track. |
+| `prev` | Skip to the previous track. |
+| `raise` | Raise the volume by `volume_step` (clamped to `max_volume` if `enforce_max_volume` is on). |
+| `lower` | Lower the volume by `volume_step`. |
+| `mute` | Toggle mute: saves the current volume and zeroes it, or restores the last saved volume if already at 0. |
+| `consume` | Toggle consume mode (played tracks are removed from the queue). |
+| `random` | Toggle random (shuffle) mode. |
+| `repeat` | Toggle repeat mode. |
+| `single` | Toggle single mode (stop, or repeat the same track, after it finishes -- depends on `repeat`). |
+
+### Example: binding in XFCE's keyboard settings
+
+Open **Settings → Keyboard → Application Shortcuts**, click **Add**, type the command (e.g. `mpd-kb-control.py play`), then press the key you want to bind it to when prompted:
+
+| Command | Key to press |
+| --- | --- |
+| `mpd-kb-control.py play` | `XF86AudioPlay` |
+| `mpd-kb-control.py next` | `XF86AudioNext` |
+| `mpd-kb-control.py prev` | `XF86AudioPrev` |
+| `mpd-kb-control.py raise` | `XF86AudioRaiseVolume` |
+| `mpd-kb-control.py lower` | `XF86AudioLowerVolume` |
+| `mpd-kb-control.py mute` | `XF86AudioMute` |
+
+XFCE often ships these keys pre-bound to its own volume OSD (via `xfce4-pulseaudio-plugin` or similar). If pressing the key doesn't prompt you to overwrite an existing shortcut, find and remove that default binding first (same Application Shortcuts list), or both will fire.
+
+The same thing scripted via `xfconf-query`, useful for provisioning more than one machine (`-n` creates the property if it doesn't exist yet, so this is safe to re-run):
+
+```bash
+xfconf-query -c xfce4-keyboard-shortcuts -p /commands/custom/XF86AudioPlay        -n -t string -s "mpd-kb-control.py play"
+xfconf-query -c xfce4-keyboard-shortcuts -p /commands/custom/XF86AudioNext        -n -t string -s "mpd-kb-control.py next"
+xfconf-query -c xfce4-keyboard-shortcuts -p /commands/custom/XF86AudioPrev        -n -t string -s "mpd-kb-control.py prev"
+xfconf-query -c xfce4-keyboard-shortcuts -p /commands/custom/XF86AudioRaiseVolume -n -t string -s "mpd-kb-control.py raise"
+xfconf-query -c xfce4-keyboard-shortcuts -p /commands/custom/XF86AudioLowerVolume -n -t string -s "mpd-kb-control.py lower"
+xfconf-query -c xfce4-keyboard-shortcuts -p /commands/custom/XF86AudioMute        -n -t string -s "mpd-kb-control.py mute"
+```
+
+### Example: a separate keypad for consume/random/repeat/single
+
+`consume`/`random`/`repeat`/`single` don't correspond to any standard multimedia key, so there's nothing to bind them to on a normal keyboard. A cheap secondary USB numpad works well as a dedicated set of MPD mode toggles instead -- XFCE's Application Shortcuts editor accepts numpad keys the exact same way it accepts multimedia keys, no extra driver or udev rule needed. Add each one the same way (Add → type the command → press the numpad key):
+
+| Command | Key to press |
+| --- | --- |
+| `mpd-kb-control.py consume` | `KP_1` |
+| `mpd-kb-control.py random` | `KP_2` |
+| `mpd-kb-control.py repeat` | `KP_3` |
+| `mpd-kb-control.py single` | `KP_4` |
+
+Or via `xfconf-query`:
+
+```bash
+xfconf-query -c xfce4-keyboard-shortcuts -p /commands/custom/KP_1 -n -t string -s "mpd-kb-control.py consume"
+xfconf-query -c xfce4-keyboard-shortcuts -p /commands/custom/KP_2 -n -t string -s "mpd-kb-control.py random"
+xfconf-query -c xfce4-keyboard-shortcuts -p /commands/custom/KP_3 -n -t string -s "mpd-kb-control.py repeat"
+xfconf-query -c xfce4-keyboard-shortcuts -p /commands/custom/KP_4 -n -t string -s "mpd-kb-control.py single"
+```
+
+If the numpad's keys don't register as `KP_1` etc. in the Application Shortcuts dialog (some cheap keypads use a NumLock-dependent or otherwise remapped layout), run `xev` and press each key to see the keysym it actually sends, then use that instead.
+
+### Bonus: Application Shortcuts aren't MPD-specific
+
+The same mechanism binds any command, not just `mpd-kb-control.py` -- useful for filling out the rest of a spare numpad. For example, opening a URL in your default browser on `KP_5`:
+
+```bash
+xfconf-query -c xfce4-keyboard-shortcuts -p /commands/custom/KP_5 -n -t string -s "xdg-open https://github.com/bonelifer/mpd-scripts"
+```
+
+or the same thing through the GUI: Add → `xdg-open https://github.com/bonelifer/mpd-scripts` → press `KP_5`. `xdg-open` picks your configured default browser; swap in `firefox`/`chromium` directly if you'd rather target a specific one.
+
+## Configuration
+
+Settings live in `~/.config/mpd-scripts/mpd-kb-control/mpd-kb-control.conf`, seeded automatically from [`mpd-kb-control.conf.example`](./mpd-kb-control.conf.example) the first time you run the script. Edit the copy there, not the template.
+
+| Setting | Description | Default |
+| --- | --- | --- |
+| `mpd_host` | MPD server hostname/IP | `localhost` |
+| `mpd_port` | MPD server port | `6600` |
+| `mpd_password` | MPD password, if required (leave blank if none) | *(blank)* |
+| `volume_step` | Percentage points adjusted per `raise`/`lower` call | `5` |
+| `enforce_max_volume` | If `true`, `raise` won't push the volume above `max_volume` | `false` |
+| `max_volume` | Ceiling used when `enforce_max_volume` is on | `100` |
+| `notify` | Show a desktop notification on play/pause/volume changes | `false` |
+
+`-H`/`--host`, `-P`/`--port`, and `-a`/`--password` override the config file for a single invocation.
+
+Mute state (the volume to restore on unmute) is stored separately in `~/.local/state/mpd-kb-control/volume_save`, since it's runtime state rather than configuration.
+
+## Known limitations
+
+Each invocation opens a fresh MPD connection and closes it -- fine for a tap, but if your window manager auto-repeats a held key (many do, around 20-25 times/sec), holding `raise`/`lower` down means that many new connections per second for as long as it's held. This is inherent to running as a one-shot CLI dispatch rather than a background daemon; if you want a smoother held-key ramp, bind the key to repeat less aggressively at the WM level instead.
+
+## Acknowledgments
+
+Based on [mpd_kb_control](https://github.com/nogaems/mpd_kb_control) by nogaems, ported from bash/`mpc` to Python 3 and `python-mpd2`. The original's play/pause detection text-scraped `mpc`'s human-readable output for a `[playing]`/`[paused]` bracket, which meant the documented "starts playback if stopped" behavior never actually worked -- there's no such bracket when MPD is stopped. Reading MPD's `state` field directly instead fixes that as a side effect of the port, alongside adding a configurable volume step, an optional max-volume ceiling (now enforced on mute-restore too, not just `raise`), desktop notifications (including on failure), race-safe mute via file locking, and toggles for MPD's consume/random/repeat/single playback modes.
+
+## License
+
+This project is licensed under the **GNU General Public License v3.0**.
+
+See [LICENSE](../LICENSE) for more information.

--- a/mpd-kb-control/mpd-kb-control.conf.example
+++ b/mpd-kb-control/mpd-kb-control.conf.example
@@ -1,0 +1,29 @@
+# mpd-kb-control configuration
+#
+# Copied to ~/.config/mpd-scripts/mpd-kb-control/mpd-kb-control.conf on
+# first run if that file doesn't already exist. Edit the copy there, not
+# this template.
+
+[mpd-kb-control]
+
+# MPD connection details. Can be overridden per invocation with
+# -H/--host, -P/--port, -a/--password.
+mpd_host = localhost
+mpd_port = 6600
+
+# Leave blank unless your MPD requires a password.
+mpd_password =
+
+# Percentage points to adjust the volume by on each "raise"/"lower" call.
+volume_step = 5
+
+# If true, "raise" won't push the volume above max_volume. "lower" is
+# never affected by this.
+enforce_max_volume = false
+max_volume = 100
+
+# Show a desktop notification (via notify-send) on play/pause/volume
+# changes. Off by default since not every setup (e.g. a bare dwm session)
+# has a notification daemon running; harmless to enable either way, since
+# a missing notify-send is silently ignored.
+notify = false

--- a/mpd-kb-control/mpd-kb-control.py
+++ b/mpd-kb-control/mpd-kb-control.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""
+mpd-kb-control
+
+Dispatches multimedia-key presses to MPD, for binding to a window manager's
+keybindings (XF86AudioPlay, XF86AudioNext, etc.).
+
+Usage:
+    mpd-kb-control.py {play,next,prev,raise,lower,mute,consume,random,repeat,single}
+
+Commands:
+    play     Toggle play/pause. If MPD is stopped, starts playback instead
+             (unlike relying on a text-scraped "[playing]"/"[paused]"
+             status, this reads MPD's actual state field directly, so the
+             stopped case is handled rather than silently doing nothing).
+    next     Skip to the next track.
+    prev     Skip to the previous track.
+    raise    Raise the volume by volume_step (clamped to max_volume, if
+             enforce_max_volume is enabled).
+    lower    Lower the volume by volume_step.
+    mute     Toggle mute: saves the current volume and sets it to 0, or
+             restores the last saved volume if already at 0.
+    consume  Toggle consume mode (played tracks are removed from the queue).
+    random   Toggle random (shuffle) mode.
+    repeat   Toggle repeat mode.
+    single   Toggle single mode (stop, or repeat the same track, after it
+             finishes, depending on repeat).
+
+None of consume/random/repeat/single have a dedicated multimedia key on a
+standard keyboard -- see README.md for examples binding them on a separate
+keypad instead.
+
+Connection settings and behavior come from
+~/.config/mpd-scripts/mpd-kb-control/mpd-kb-control.conf, seeded from
+mpd-kb-control.conf.example on first run.
+"""
+
+import argparse
+import configparser
+import fcntl
+import os
+import subprocess
+import sys
+
+from mpd import MPDClient, CommandError
+from socket import error as SocketError
+
+CONFIG_DIR = os.path.join(os.path.expanduser("~"), ".config", "mpd-scripts", "mpd-kb-control")
+CONFIG_FILE = os.path.join(CONFIG_DIR, "mpd-kb-control.conf")
+
+STATE_DIR = os.path.join(os.path.expanduser("~"), ".local", "state", "mpd-kb-control")
+VOLUME_SAVE_FILE = os.path.join(STATE_DIR, "volume_save")
+MUTE_LOCK_FILE = os.path.join(STATE_DIR, "mute.lock")
+
+
+def die(msg: str) -> None:
+    """Print an error message to stderr and exit with status 1."""
+    sys.stderr.write(msg)
+    sys.stderr.write("\n")
+    sys.exit(1)
+
+
+def load_config() -> configparser.SectionProxy:
+    """Load ~/.config/mpd-scripts/mpd-kb-control/mpd-kb-control.conf, seeding
+    it from the mpd-kb-control.conf.example template shipped alongside this
+    script on first run.
+
+    Returns:
+        configparser.SectionProxy: the "mpd-kb-control" section.
+    """
+    if not os.path.exists(CONFIG_FILE):
+        os.makedirs(CONFIG_DIR, mode=0o700, exist_ok=True)
+        template = os.path.join(os.path.dirname(os.path.abspath(__file__)), "mpd-kb-control.conf.example")
+        with open(template) as src, open(CONFIG_FILE, "w") as dst:
+            dst.write(src.read())
+        os.chmod(CONFIG_FILE, 0o600)  # May contain an MPD password
+
+    config = configparser.ConfigParser()
+    config.read(CONFIG_FILE)
+    return config["mpd-kb-control"]
+
+
+def notify(config: configparser.SectionProxy, message: str) -> None:
+    """Show a desktop notification via notify-send, if notify is enabled in
+    the config and notify-send is available. Never fatal -- a missing
+    notification daemon (e.g. on a headless or minimal WM setup) shouldn't
+    break volume/playback control."""
+    if not config.getboolean("notify", fallback=False):
+        return
+    try:
+        subprocess.run(["notify-send", "MPD", message], check=False, capture_output=True)
+    except FileNotFoundError:
+        pass
+
+
+def cmd_play(client: MPDClient, config: configparser.SectionProxy) -> None:
+    """Toggle play/pause; starts playback if MPD is currently stopped."""
+    state = client.status()["state"]
+    if state == "play":
+        client.pause(1)
+        notify(config, "Paused")
+    else:
+        client.play()
+        notify(config, "Playing")
+
+
+def cmd_next(client: MPDClient, config: configparser.SectionProxy) -> None:
+    client.next()
+
+
+def cmd_prev(client: MPDClient, config: configparser.SectionProxy) -> None:
+    client.previous()
+
+
+def _adjust_volume(client: MPDClient, config: configparser.SectionProxy, delta: int) -> None:
+    current = int(client.status().get("volume", 0))
+    target = max(0, min(100, current + delta))
+
+    if delta > 0 and config.getboolean("enforce_max_volume", fallback=False):
+        max_volume = config.getint("max_volume", fallback=100)
+        target = min(target, max_volume)
+
+    client.setvol(target)
+    notify(config, f"Volume: {target}%")
+
+
+def cmd_raise(client: MPDClient, config: configparser.SectionProxy) -> None:
+    step = config.getint("volume_step", fallback=5)
+    _adjust_volume(client, config, step)
+
+
+def cmd_lower(client: MPDClient, config: configparser.SectionProxy) -> None:
+    step = config.getint("volume_step", fallback=5)
+    _adjust_volume(client, config, -step)
+
+
+def cmd_mute(client: MPDClient, config: configparser.SectionProxy) -> None:
+    """Toggle mute: save the current (non-zero) volume and zero it, or
+    restore the last saved volume if already at 0.
+
+    Held under an exclusive file lock spanning both the MPD status check
+    and the save-file read/write, so two mute invocations firing close
+    together (a double-tap, or a duplicate keybinding) serialize instead
+    of racing -- the second one waits for the first to finish rather than
+    both reading the pre-mute volume and stepping on each other's save.
+    """
+    os.makedirs(STATE_DIR, exist_ok=True)
+    with open(MUTE_LOCK_FILE, "w") as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX)
+
+        current_volume = int(client.status().get("volume", 0))
+        if current_volume != 0:
+            with open(VOLUME_SAVE_FILE, "w") as f:
+                f.write(str(current_volume))
+            client.setvol(0)
+            notify(config, "Muted")
+        else:
+            try:
+                with open(VOLUME_SAVE_FILE) as f:
+                    saved_volume = int(f.read().strip())
+            except (FileNotFoundError, ValueError):
+                saved_volume = 0
+
+            if config.getboolean("enforce_max_volume", fallback=False):
+                max_volume = config.getint("max_volume", fallback=100)
+                saved_volume = min(saved_volume, max_volume)
+
+            client.setvol(saved_volume)
+            notify(config, f"Unmuted ({saved_volume}%)")
+
+
+def _make_toggle(mode: str, setter_name: str, label: str):
+    """Build a command function that toggles one of MPD's boolean playback
+    modes (consume/random/repeat/single): reads the current 0/1 value from
+    status(), flips it via the matching setter method, and notifies."""
+
+    def toggle(client: MPDClient, config: configparser.SectionProxy) -> None:
+        current = client.status().get(mode, "0")
+        new_value = 0 if current == "1" else 1
+        getattr(client, setter_name)(new_value)
+        notify(config, f"{label}: {'on' if new_value else 'off'}")
+
+    toggle.__doc__ = f"Toggle {mode} mode."
+    return toggle
+
+
+cmd_consume = _make_toggle("consume", "consume", "Consume")
+cmd_random = _make_toggle("random", "random", "Random")
+cmd_repeat = _make_toggle("repeat", "repeat", "Repeat")
+cmd_single = _make_toggle("single", "single", "Single")
+
+
+COMMANDS = {
+    "play": cmd_play,
+    "next": cmd_next,
+    "prev": cmd_prev,
+    "raise": cmd_raise,
+    "lower": cmd_lower,
+    "mute": cmd_mute,
+    "consume": cmd_consume,
+    "random": cmd_random,
+    "repeat": cmd_repeat,
+    "single": cmd_single,
+}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Dispatch multimedia-key presses to MPD.")
+    parser.add_argument("command", choices=sorted(COMMANDS), help="Action to perform")
+    parser.add_argument("-H", "--host", default=None, help="MPD host. Overrides mpd-kb-control.conf.")
+    parser.add_argument("-P", "--port", default=None, type=int, help="MPD port. Overrides mpd-kb-control.conf.")
+    parser.add_argument("-a", "--password", default=None, help="MPD password. Overrides mpd-kb-control.conf.")
+    args = parser.parse_args()
+
+    config = load_config()
+    host = args.host or config.get("mpd_host", fallback="localhost")
+    port = args.port or config.getint("mpd_port", fallback=6600)
+    password = args.password or config.get("mpd_password", fallback="") or None
+
+    client = MPDClient()
+    try:
+        client.connect(host, port)
+    except SocketError as e:
+        # Invoked from a keybinding with no visible terminal, so stderr
+        # alone would be silently lost -- surface failures as a
+        # notification too (when enabled), not just an exit code no one
+        # sees.
+        notify(config, "Failed to connect to MPD")
+        die(f"Failed to connect to MPD server: {e}")
+    if password:
+        try:
+            client.password(password)
+        except CommandError as e:
+            notify(config, "MPD authentication failed")
+            die(f"Error authenticating with MPD: {e}")
+
+    try:
+        COMMANDS[args.command](client, config)
+    except CommandError as e:
+        # Covers cases like play/next/prev on an empty queue, or setvol
+        # with no mixer configured -- previously an uncaught traceback
+        # dumped nowhere visible instead of a clean, notified failure.
+        notify(config, f"'{args.command}' failed")
+        die(f"MPD command failed: {e}")
+
+    client.close()
+    client.disconnect()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Two independent pieces of work, bundled into one PR:

**alarmpd: `--prune`**
- One-shot alarms never reschedule once their date passes, but the stored playlist was never deleted either -- `--prune` connects, finds expired one-shot alarms, and removes them. Recurring and disabled alarms are untouched.

**New tool: mpd-kb-control**
- Ports [nogaems/mpd_kb_control](https://github.com/nogaems/mpd_kb_control) from bash/`mpc` to Python 3 and `python-mpd2`.
- Fixes a real bug in the original: play/pause/stopped detection text-scraped `mpc`'s output for a `[playing]`/`[paused]` bracket, so the documented "starts playback if stopped" behavior never worked (no such bracket exists when MPD is stopped). Reading MPD's `state` field directly fixes this.
- Adds: configurable volume step, an optional max-volume ceiling (enforced on mute-restore too, not just raise), desktop notifications including on failure (this runs from a keybinding with no visible terminal), race-safe mute via file locking, and toggles for MPD's consume/random/repeat/single modes with XFCE keypad-binding examples.
- Registered in the top-level README and `install.sh`.

## Test plan
- [x] `python3 -m py_compile` on both scripts
- [x] alarmpd `--prune`: verified against a mocked MPD client (prunes only past one-shot alarms; recurring/disabled/future one-shots untouched)
- [x] mpd-kb-control: all commands (play across all 3 states, next/prev, raise/lower with clamping, mute/unmute, consume/random/repeat/single) verified against a mocked MPD client
- [x] mpd-kb-control: mute race-safety (file lock), max_volume enforcement on unmute, and CommandError/connection-failure handling all verified
- [x] Config seeding, permissions, and CLI help output checked end-to-end for both

🤖 Generated with [Claude Code](https://claude.com/claude-code)