### PR TITLE
Add mpd-auto-stop: sleep-timer daemon for MPD with web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Collection of scripts related to mpd & mpc.
 | **[mpdmark](./mpdmark/)** | Bookmark playback positions in MPD via stickers, with multiple named bookmarks per song, listing, loading, renaming, deleting, and pruning stale entries. |
 | **[alarmpd](./alarmpd/)** | Playlist-named alarm clock daemon: schedule alarms by creating/renaming an MPD playlist, with multi-day/named-group and one-shot forms, per-alarm volume caps, gentle fade-in with snooze, one-time skip, and collision detection. |
 | **[mpd-kb-control](./mpd-kb-control/)** | Dispatches multimedia-key presses (play/pause/next/prev/volume/mute) to MPD, plus consume/random/repeat/single mode toggles for a separate keypad, for binding in a window manager's keybindings. |
+| **[mpd-auto-stop](./mpd-auto-stop/)** | Sleep-timer daemon with a web UI: start/extend/cancel a countdown, and it fades the volume out and pauses MPD when it fires instead of cutting off abruptly. |
 | **[mpd-recent-tracks](./mpd-recent-tracks/)** | Generates an M3U playlist (newest first) of music files added or modified in the last N days, optionally capped in size and auto-loaded into MPD, paused or playing. |
 | **[mpc-fade](./mpc-fade/)** | Fades MPD playback volume smoothly to a target level over a duration, or fades out/toggles play-pause/fades back in, using either MPD's own volume or a PulseAudio sink-input stream. |
 | **[playpause](./playpause/)** | Prints the currently playing MPD track prefixed with a play/pause symbol, for use in a status bar (polybar, i3blocks, xmobar, etc). |
@@ -67,7 +68,7 @@ Run [`./install.sh`](./install.sh) once — no manual copying needed. It:
 2. Checks whether a personal bin directory is already on your `PATH`, and, if not, creates `~/bin` and adds it for you. It also offers to create `~/bin/music` and add it to your `PATH` too, an optional separate directory for installing this repo's scripts, kept apart from other personal scripts in `~/bin`.
 3. Offers to install any missing apt/pip/cpan dependencies the scripts below need (`mpc`, `curl`, `jq`, PyQt5, PyGObject/GTK3, `pylast`, `python-mpd2`, the Perl `StreamFinder` modules, etc.).
 4. Copies every standalone script (and whatever companion file it needs alongside it, e.g. a `.conf.example` template or a station list) into the directory from step 2, and installs MPD Notifier via its own installer.
-5. Offers to install the optional MPD Rewind Daemon, prompting you to choose between two methods (`install-xdg-autostart.sh` or `install-systemd.sh`, with a clear recommendation either way — see [`mpd_rewind_daemon/README.md`](./mpd_rewind_daemon/) for details); the optional [`mpd-smart-shuffle`](./mpd-smart-shuffle/) tool (history-aware smarter shuffle, with its own optional `systemd --user` background monitor); the optional [`alarmpd`](./alarmpd/) tool (playlist-named alarm clock daemon, with the same XDG-autostart/systemd `--user` install choice); and the optional volume control scripts, prompting you to choose between the `mpc`- and `python-mpd2`-based variants (installing only one, since both use the same filenames).
+5. Offers to install the optional MPD Rewind Daemon, prompting you to choose between two methods (`install-xdg-autostart.sh` or `install-systemd.sh`, with a clear recommendation either way — see [`mpd_rewind_daemon/README.md`](./mpd_rewind_daemon/) for details); the optional [`mpd-smart-shuffle`](./mpd-smart-shuffle/) tool (history-aware smarter shuffle, with its own optional `systemd --user` background monitor); the optional [`alarmpd`](./alarmpd/) tool (playlist-named alarm clock daemon, with the same XDG-autostart/systemd `--user` install choice); the optional [`mpd-auto-stop`](./mpd-auto-stop/) tool (sleep-timer web UI daemon, same install choice again); and the optional volume control scripts, prompting you to choose between the `mpc`- and `python-mpd2`-based variants (installing only one, since both use the same filenames).
 
 Check each script's own README for usage notes once it's installed.
 
@@ -87,6 +88,7 @@ Contributions are welcome!
 - [mpdmark](./mpdmark/) is based on `mpdmark` from [Mic92/mpdtools](https://github.com/Mic92/mpdtools).
 - [alarmpd](./alarmpd/) is based on [alarmpd](https://github.com/ingobecker/alarmpd) by Ingo Becker.
 - [mpd-kb-control](./mpd-kb-control/) is based on [mpd_kb_control](https://github.com/nogaems/mpd_kb_control) by nogaems.
+- [mpd-auto-stop](./mpd-auto-stop/) is based on [mpd_auto_stop](https://github.com/vms20591/mpd_auto_stop) by Meenakshi Sundaram V.
 - Documentation updates assisted by [Claude](https://www.anthropic.com/claude).
 
 ## License

--- a/install.sh
+++ b/install.sh
@@ -15,8 +15,8 @@
 #    the directory chosen in step 2, and installs MPD Notifier via its own
 #    installer.
 # 5. Offers to install the optional MPD Rewind Daemon, mpd-smart-shuffle,
-#    alarmpd, and volume control scripts, each delegating to its own
-#    installer.
+#    alarmpd, mpd-auto-stop, and volume control scripts, each delegating to
+#    its own installer.
 #
 # Run this once; no manual copying into your PATH is needed afterwards.
 
@@ -398,6 +398,27 @@ offer_alarmpd() {
     fi
 }
 
+# Offers to install the optional mpd-auto-stop tool (sleep-timer daemon
+# with a web UI), delegating to its own installer chooser if you say yes,
+# for the same reason as offer_mpd_rewind_daemon above -- it's multi-file
+# and has its own optional systemd --user service to offer.
+offer_mpd_auto_stop() {
+    local auto_stop_installer="$SCRIPT_DIR/mpd-auto-stop/install.sh"
+
+    if [ ! -x "$auto_stop_installer" ]; then
+        return
+    fi
+
+    echo
+    read -r -p "Also install the optional mpd-auto-stop tool (sleep-timer web UI, fades out and pauses MPD)? [y/N] " REPLY
+
+    if [[ "$REPLY" =~ ^[Yy]$ ]]; then
+        "$auto_stop_installer" || echo "mpd-auto-stop installation did not complete successfully; you can retry with mpd-auto-stop/install.sh." >&2
+    else
+        echo "Skipped. Run mpd-auto-stop/install.sh later if you change your mind."
+    fi
+}
+
 # Installs MPD Notifier (desktop notification on track change) by
 # delegating to its own installer, unconditionally -- unlike the rewind
 # daemon or volume scripts below, there's no conflicting choice to make
@@ -468,5 +489,6 @@ install_mpd_notifier
 offer_mpd_rewind_daemon
 offer_mpd_smart_shuffle
 offer_alarmpd
+offer_mpd_auto_stop
 offer_volume_scripts
 print_migration_summary

--- a/mpd-auto-stop/README.md
+++ b/mpd-auto-stop/README.md
@@ -1,0 +1,123 @@
+# mpd-auto-stop
+
+A sleep-timer daemon for MPD: a small web UI and JSON API to start a countdown, and when it expires, fade the volume out and pause playback -- instead of cutting off abruptly mid-song.
+
+## Features
+
+* Web UI with preset duration buttons (+15m/+30m/+45m/+1h/+1.5h/+2h), a custom-duration field, and a live countdown -- usable from a phone browser on the same network, no app needed
+* Light/dark/auto theme, following the system preference by default, remembered across visits
+* Gentle fade-out over a configurable duration ending exactly when the timer would otherwise fire, instead of an abrupt `pause`; the pre-fade volume is restored right after pausing so the next play isn't silently at 0%
+* Optional warning hook a configurable number of seconds before the timer fires, and a stop hook once it does -- shell commands, so they can drive a desktop notification, a push notification (e.g. `ntfy`), or a home-automation webhook, since this commonly runs headless with no notification daemon of its own
+* Start / stop / restart / extend an active timer, same JSON API shape as the original tool this is based on
+* Runs on Python 3 + `python-mpd2` only -- no web framework
+
+## Requirements
+
+* Python 3
+* [`python-mpd2`](https://pypi.org/project/python-mpd2/)
+* MPD running and reachable (defaults to `localhost:6600`; see Configuration)
+
+## Installation
+
+To install and configure mpd-auto-stop, clone or download this repository, then pick **one** of the following (don't run both).
+
+Run [`./install.sh`](./install.sh) to be prompted which one you want (defaults to Option A after 30 seconds), or run either script directly if you already know:
+
+### Option A: XDG autostart (default)
+
+```bash
+./install-xdg-autostart.sh
+```
+
+This script performs the following actions:
+
+* Installs `python-mpd2` locally using `pip3`
+* Copies `mpd-auto-stop.py`, `mpd-auto-stop.conf.example`, and `index.html` to `~/bin/`
+* Ensures `~/bin` and `~/.local/bin` are in your `PATH`
+* Creates an autostart entry in `~/.config/autostart/mpd-auto-stop.desktop`
+
+After installation, restart your shell or run `source ~/.bashrc`. The daemon will automatically start on your next login.
+
+### Option B: systemd `--user` service
+
+```bash
+./install-systemd.sh
+```
+
+This is an alternative to the XDG autostart entry, using [`mpd-auto-stop.service`](./mpd-auto-stop.service) instead: it installs and enables a `systemd --user` unit, which gives you auto-restart on crash and logs viewable via `journalctl` instead of the daemon's own log file. It runs the daemon with `--verbose` (foreground mode) under the hood, since that's what `Type=simple` expects.
+
+```bash
+systemctl --user status mpd-auto-stop.service
+journalctl --user -u mpd-auto-stop.service -f
+```
+
+This also works on a headless machine with no desktop session (e.g. the Raspberry Pi the original tool was written for) -- run `sudo loginctl enable-linger $USER` once so the service keeps running after you log out.
+
+Either way, the daemon creates its own state directory (`~/.local/state/mpd-auto-stop/`) and config directory (`~/.config/mpd-scripts/mpd-auto-stop/`) the first time it runs -- no `sudo` needed anywhere in installation.
+
+## Usage
+
+Open `http://<host>:9090/` (or whatever `http_host`/`http_port` you've configured) in a browser for the web UI, or use the JSON API directly:
+
+| Endpoint | Description |
+| --- | --- |
+| `GET /timer` | Status: `{"status": "stopped"}` or `{"status": "started", "remaining_seconds": 930, "fading": false}` |
+| `GET /timer/<duration>/start` | Start a timer. `<duration>` like `45m`, `1h`, `1.5h`, `3600s`. |
+| `GET /timer/stop` | Cancel the running timer (just cancels the countdown -- doesn't pause playback itself). |
+| `GET /timer/restart` | Re-arm the running timer with its original duration. |
+| `GET /timer/<duration>/extend` | Add more time to the running timer. |
+
+Stop the daemon (Option A / XDG autostart install):
+```bash
+mpd-auto-stop.py --stop
+```
+If you installed via `install-systemd.sh` (Option B) instead, use `systemctl --user stop mpd-auto-stop.service`.
+
+Run manually in the foreground (for debugging):
+```bash
+mpd-auto-stop.py --verbose
+```
+
+## Configuration
+
+Settings live in `~/.config/mpd-scripts/mpd-auto-stop/mpd-auto-stop.conf`, seeded automatically from [`mpd-auto-stop.conf.example`](./mpd-auto-stop.conf.example) the first time you run the script. Edit the copy there, not the template.
+
+| Setting | Description | Default |
+| --- | --- | --- |
+| `http_host` | Address the web server listens on | `0.0.0.0` |
+| `http_port` | Port the web server listens on | `9090` |
+| `http_username` | Optional HTTP Basic Auth username (leave blank with `http_password` to disable) | *(blank)* |
+| `http_password` | Optional HTTP Basic Auth password | *(blank)* |
+| `mpd_host` | MPD server hostname/IP | `localhost` |
+| `mpd_port` | MPD server port | `6600` |
+| `mpd_password` | MPD password, if required (leave blank if none) | *(blank)* |
+| `fade_duration` | Seconds to fade the volume to 0, ending when the timer fires (0 = instant pause) | `300` |
+| `warning_lead_time` | Seconds before firing to run `warning_hook` (0 = disabled) | `60` |
+| `warning_hook` | Shell command run `warning_lead_time` seconds before the timer fires | *(blank)* |
+| `stop_hook` | Shell command run once playback is actually paused | *(blank)* |
+
+`-a`/`--http-host`, `-p`/`--http-port`, `-U`/`--http-username`, `-W`/`--http-password`, `-H`/`--mpd-host`, `-P`/`--mpd-port`, and `-w`/`--mpd-password` override the config file for a single invocation.
+
+## Security
+
+The server has no access control by default and listens on `0.0.0.0` -- anyone on the same network can start/stop your timer. Set `http_username`/`http_password` (or `-U`/`-W`) to require HTTP Basic Auth on every request, including the web UI itself. Still worth keeping this off the open internet regardless; Basic Auth over plain HTTP protects against casual same-network access, not a hostile one.
+
+## How fading works
+
+`fade_duration` sets how many seconds it takes to ramp the volume down to 0, timed to finish exactly when the timer would otherwise fire -- a 1-hour timer with a 5-minute `fade_duration` stays at full volume for the first 55 minutes, then tapers off over the last 5. If `fade_duration` is longer than the timer itself, it's clamped down to fit rather than pushing the actual stop time later than requested. `warning_lead_time` fires independently at its own offset, whether that lands before, during, or (in a degenerate config) right at the moment of the fade completing -- either way it always fires exactly once and the timer never runs past the requested duration. Cancelling (`stop`), `restart`ing, or `extend`ing a timer mid-fade immediately restores the volume to what it was before fading started, since those all mean "keep playing normally," not "pause now."
+
+## Logging
+
+Logs are written to `~/.local/state/mpd-auto-stop/mpd-auto-stop.log`. With `--verbose`, logs go to the console instead, and the daemon doesn't fork to the background -- useful for debugging.
+
+## Acknowledgments
+
+Based on [mpd_auto_stop](https://github.com/vms20591/mpd_auto_stop) by Meenakshi Sundaram V. The original had two bugs fixed in this port: every error-response code path called the Python 2-only `exp.message` attribute, which was removed in Python 3 and made every error path raise an unhandled `AttributeError` instead of returning the intended JSON error body; and the server drove a private `_handle_request_noblock()` method directly instead of the public `serve_forever()`/`shutdown()` API, which meant a `SIGTERM` (e.g. from `systemctl stop`) wouldn't actually take effect until the next incoming HTTP request happened to arrive. Also dropped the Python 2 compatibility shims (Python 3 only now), and added the fade-out, warning/stop hooks, optional HTTP Basic Auth, and the web UI on top of the original's bare JSON API and link list.
+
+A third bug was introduced and fixed during this port's own development: the warning and fade were originally chained sequentially ("wait for the warning, then wait for the rest of `fade_duration`"), which only produced the intended timing when `warning_lead_time > fade_duration`. With the shipped defaults (`fade_duration=300` > `warning_lead_time=60`) it actually ran the timer past its requested duration. Fixed by scheduling both as independent absolute-offset checkpoints and clamping the fade to whatever time is actually left, rather than always running for the full configured `fade_duration`.
+
+## License
+
+This project is licensed under the **GNU General Public License v3.0**.
+
+See [LICENSE](../LICENSE) for more information.

--- a/mpd-auto-stop/index.html
+++ b/mpd-auto-stop/index.html
@@ -1,0 +1,313 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>MPD Auto Stop</title>
+<style>
+  :root {
+    --bg: #f5f5f5;
+    --fg: #1a1a1a;
+    --muted: #666;
+    --button-bg: #ffffff;
+    --button-border: #ccc;
+    --button-hover: #e8e8e8;
+    --accent: #2a6f97;
+    --accent-fg: #ffffff;
+    --danger: #a33;
+    --danger-fg: #ffffff;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #1e1e1e;
+      --fg: #e8e8e8;
+      --muted: #a0a0a0;
+      --button-bg: #2a2a2a;
+      --button-border: #444;
+      --button-hover: #383838;
+      --accent: #4d9fd6;
+      --accent-fg: #101010;
+      --danger: #c46;
+      --danger-fg: #101010;
+    }
+  }
+
+  html[data-theme="light"] {
+    --bg: #f5f5f5;
+    --fg: #1a1a1a;
+    --muted: #666;
+    --button-bg: #ffffff;
+    --button-border: #ccc;
+    --button-hover: #e8e8e8;
+    --accent: #2a6f97;
+    --accent-fg: #ffffff;
+    --danger: #a33;
+    --danger-fg: #ffffff;
+  }
+
+  html[data-theme="dark"] {
+    --bg: #1e1e1e;
+    --fg: #e8e8e8;
+    --muted: #a0a0a0;
+    --button-bg: #2a2a2a;
+    --button-border: #444;
+    --button-hover: #383838;
+    --accent: #4d9fd6;
+    --accent-fg: #101010;
+    --danger: #c46;
+    --danger-fg: #101010;
+  }
+
+  * { box-sizing: border-box; }
+
+  body {
+    font-family: system-ui, sans-serif, verdana;
+    background: var(--bg);
+    color: var(--fg);
+    margin: 0;
+    padding: 1.5rem;
+    max-width: 480px;
+    margin: 0 auto;
+  }
+
+  h1 {
+    font-size: 2.2rem;
+    text-align: center;
+    margin: 0.5rem 0 1.5rem;
+  }
+
+  .theme-picker {
+    display: flex;
+    justify-content: center;
+    gap: 0.25rem;
+    margin-bottom: 1.5rem;
+  }
+
+  .theme-picker button {
+    font-size: 0.75rem;
+    padding: 0.25rem 0.6rem;
+  }
+
+  .theme-picker button[aria-pressed="true"] {
+    background: var(--accent);
+    color: var(--accent-fg);
+    border-color: var(--accent);
+  }
+
+  #status {
+    text-align: center;
+    font-size: 1.4rem;
+    font-weight: 600;
+    margin: 1rem 0;
+    min-height: 2.2rem;
+  }
+
+  #status.fading {
+    color: var(--danger);
+  }
+
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 0.6rem;
+    margin-bottom: 1rem;
+  }
+
+  button {
+    font-size: 1rem;
+    padding: 0.7rem;
+    border-radius: 0.4rem;
+    border: 1px solid var(--button-border);
+    background: var(--button-bg);
+    color: var(--fg);
+    cursor: pointer;
+  }
+
+  button:hover {
+    background: var(--button-hover);
+  }
+
+  button:active {
+    transform: scale(0.98);
+  }
+
+  .row {
+    display: flex;
+    gap: 0.6rem;
+    margin-bottom: 0.6rem;
+  }
+
+  .row button {
+    flex: 1;
+  }
+
+  #cancel-btn {
+    width: 100%;
+    background: var(--danger);
+    color: var(--danger-fg);
+    border-color: var(--danger);
+  }
+
+  form#custom-form {
+    display: flex;
+    gap: 0.6rem;
+    margin-bottom: 1.5rem;
+  }
+
+  form#custom-form input {
+    flex: 1;
+    font-size: 1rem;
+    padding: 0.6rem;
+    border-radius: 0.4rem;
+    border: 1px solid var(--button-border);
+    background: var(--button-bg);
+    color: var(--fg);
+  }
+
+  #error {
+    color: var(--danger);
+    text-align: center;
+    min-height: 1.2rem;
+    font-size: 0.9rem;
+  }
+</style>
+</head>
+<body>
+
+<h1>MPD Auto Stop</h1>
+
+<div class="theme-picker" role="group" aria-label="Theme">
+  <button type="button" data-theme-choice="light">Light</button>
+  <button type="button" data-theme-choice="dark">Dark</button>
+  <button type="button" data-theme-choice="auto">Auto</button>
+</div>
+
+<div id="status">Loading&hellip;</div>
+<div id="error"></div>
+
+<div class="grid">
+  <button type="button" data-duration="15m">+15m</button>
+  <button type="button" data-duration="30m">+30m</button>
+  <button type="button" data-duration="45m">+45m</button>
+  <button type="button" data-duration="1h">+1h</button>
+  <button type="button" data-duration="1.5h">+1.5h</button>
+  <button type="button" data-duration="2h">+2h</button>
+</div>
+
+<form id="custom-form">
+  <input type="text" id="custom-duration" placeholder="e.g. 20m, 1h, 90s" pattern="[0-9.]+[smh]" required>
+  <button type="submit">Start</button>
+</form>
+
+<button type="button" id="cancel-btn">Cancel timer</button>
+
+<script>
+(function () {
+  "use strict";
+
+  var STATUS_POLL_MS = 3000;
+  var statusEl = document.getElementById("status");
+  var errorEl = document.getElementById("error");
+
+  function showError(message) {
+    errorEl.textContent = message || "";
+  }
+
+  function formatRemaining(seconds) {
+    seconds = Math.max(0, Math.round(seconds));
+    var h = Math.floor(seconds / 3600);
+    var m = Math.floor((seconds % 3600) / 60);
+    var s = seconds % 60;
+    var parts = [];
+    if (h > 0) parts.push(h + "h");
+    if (h > 0 || m > 0) parts.push(m + "m");
+    parts.push(s + "s");
+    return parts.join(" ");
+  }
+
+  function refreshStatus() {
+    fetch("/timer")
+      .then(function (res) { return res.json(); })
+      .then(function (data) {
+        if (data.status === "started") {
+          statusEl.textContent = formatRemaining(data.remaining_seconds) + " remaining";
+          statusEl.classList.toggle("fading", !!data.fading);
+        } else {
+          statusEl.textContent = "Stopped";
+          statusEl.classList.remove("fading");
+        }
+      })
+      .catch(function () {
+        statusEl.textContent = "Unable to reach server";
+      });
+  }
+
+  function callAction(path) {
+    showError("");
+    fetch(path)
+      .then(function (res) {
+        return res.json().then(function (data) {
+          if (!res.ok) {
+            throw new Error(data.error || "Request failed");
+          }
+          return data;
+        });
+      })
+      .then(refreshStatus)
+      .catch(function (err) {
+        showError(err.message);
+      });
+  }
+
+  document.querySelectorAll("[data-duration]").forEach(function (btn) {
+    btn.addEventListener("click", function () {
+      callAction("/timer/" + encodeURIComponent(btn.dataset.duration) + "/start");
+    });
+  });
+
+  document.getElementById("cancel-btn").addEventListener("click", function () {
+    callAction("/timer/stop");
+  });
+
+  document.getElementById("custom-form").addEventListener("submit", function (evt) {
+    evt.preventDefault();
+    var input = document.getElementById("custom-duration");
+    var value = input.value.trim();
+    if (!value) return;
+    callAction("/timer/" + encodeURIComponent(value) + "/start");
+    input.value = "";
+  });
+
+  // --- theme picker ---
+  var THEME_KEY = "mpd-auto-stop-theme";
+
+  function applyTheme(theme) {
+    if (theme === "auto") {
+      document.documentElement.removeAttribute("data-theme");
+    } else {
+      document.documentElement.setAttribute("data-theme", theme);
+    }
+    document.querySelectorAll("[data-theme-choice]").forEach(function (btn) {
+      btn.setAttribute("aria-pressed", String(btn.dataset.themeChoice === theme));
+    });
+  }
+
+  document.querySelectorAll("[data-theme-choice]").forEach(function (btn) {
+    btn.addEventListener("click", function () {
+      var theme = btn.dataset.themeChoice;
+      localStorage.setItem(THEME_KEY, theme);
+      applyTheme(theme);
+    });
+  });
+
+  applyTheme(localStorage.getItem(THEME_KEY) || "auto");
+
+  // --- status polling ---
+  refreshStatus();
+  setInterval(refreshStatus, STATUS_POLL_MS);
+})();
+</script>
+
+</body>
+</html>

--- a/mpd-auto-stop/install-systemd.sh
+++ b/mpd-auto-stop/install-systemd.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/bash
+
+# mpd-auto-stop systemd --user service installer
+#
+# Alternative to install-xdg-autostart.sh's XDG autostart .desktop entry:
+# installs and enables mpd-auto-stop.py as a systemd --user service
+# instead, giving auto-restart on crash and journald logging. Run
+# ../install.sh first if ~/bin isn't already on your PATH. Don't run both
+# installers -- pick one.
+#
+# Works fine on a headless machine too (e.g. the Raspberry Pi this tool
+# was originally written for) via `loginctl enable-linger $USER`, so a
+# systemd --user service doesn't require an active desktop session.
+
+set -e  # Exit on error
+
+INSTALL_DIR="$HOME/bin"
+SCRIPT_NAME="mpd-auto-stop.py"
+CONF_EXAMPLE="mpd-auto-stop.conf.example"
+TEMPLATE="index.html"
+UNIT_NAME="mpd-auto-stop.service"
+UNIT_DIR="$HOME/.config/systemd/user"  # Per-user systemd unit search path
+
+echo "Installing mpd-auto-stop (systemd --user service)..."
+
+mkdir -p "$INSTALL_DIR"
+
+echo "Installing python-mpd2..."
+pip3 install --user python-mpd2
+
+echo "Copying daemon script to $INSTALL_DIR/$SCRIPT_NAME..."
+cp "$SCRIPT_NAME" "$INSTALL_DIR/$SCRIPT_NAME"
+chmod +x "$INSTALL_DIR/$SCRIPT_NAME"
+cp "$CONF_EXAMPLE" "$INSTALL_DIR/$CONF_EXAMPLE"
+cp "$TEMPLATE" "$INSTALL_DIR/$TEMPLATE"
+
+mkdir -p "$UNIT_DIR"
+echo "Installing systemd unit to $UNIT_DIR/$UNIT_NAME..."
+cp "$UNIT_NAME" "$UNIT_DIR/$UNIT_NAME"
+
+# Re-scan unit files for the new one, then start it now and mark it to
+# start automatically on every future login.
+systemctl --user daemon-reload
+systemctl --user enable --now "$UNIT_NAME"
+
+echo "Installation complete! Check status with:"
+echo "  systemctl --user status $UNIT_NAME"
+echo "View logs with:"
+echo "  journalctl --user -u $UNIT_NAME -f"
+echo
+echo "Running on a headless machine? Run this once so the service keeps"
+echo "running after you log out:"
+echo "  sudo loginctl enable-linger \$USER"

--- a/mpd-auto-stop/install-xdg-autostart.sh
+++ b/mpd-auto-stop/install-xdg-autostart.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/bash
+
+# mpd-auto-stop Installer -- XDG autostart entry
+#
+# Installs mpd-auto-stop.py to ~/bin and creates a
+# ~/.config/autostart/mpd-auto-stop.desktop entry so it starts
+# automatically at login. See install-systemd.sh for a systemd --user
+# service alternative instead. Don't run both installers -- pick one.
+
+set -e  # Exit on error
+
+INSTALL_DIR="$HOME/bin"
+SCRIPT_NAME="mpd-auto-stop.py"
+CONF_EXAMPLE="mpd-auto-stop.conf.example"
+TEMPLATE="index.html"
+SCRIPT_PATH="$INSTALL_DIR/$SCRIPT_NAME"
+AUTOSTART_ENTRY="$SCRIPT_PATH"  # Autostart entry for the daemon (already executable with its own shebang)
+DESKTOP_FILE="$HOME/.config/autostart/mpd-auto-stop.desktop"
+
+echo "Installing mpd-auto-stop..."
+
+# Ensure ~/bin exists and add it to PATH
+if [ ! -d "$INSTALL_DIR" ]; then
+    echo "Creating $INSTALL_DIR..."
+    mkdir -p "$INSTALL_DIR"
+
+    # Since ~/bin didn't exist, assume it's not in PATH and add it
+    echo 'export PATH="$HOME/bin:$PATH"' >> "$HOME/.bashrc"
+    echo "Added ~/bin to PATH in .bashrc"
+fi
+
+# Ensure ~/.local/bin is in PATH for pip installs
+if ! echo "$PATH" | grep -q "$HOME/.local/bin"; then
+    echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$HOME/.bashrc"
+    echo "Added ~/.local/bin to PATH in .bashrc"
+fi
+
+# Install dependencies
+echo "Installing python-mpd2..."
+pip3 install --user python-mpd2
+
+# Copy daemon script and its companion files to ~/bin
+echo "Copying daemon script to $SCRIPT_PATH..."
+cp "$SCRIPT_NAME" "$SCRIPT_PATH"
+chmod +x "$SCRIPT_PATH"
+cp "$CONF_EXAMPLE" "$INSTALL_DIR/$CONF_EXAMPLE"
+cp "$TEMPLATE" "$INSTALL_DIR/$TEMPLATE"
+
+# Ensure the autostart directory exists
+mkdir -p "$HOME/.config/autostart"
+
+# Check if the autostart entry already exists
+if ! grep -q "Exec=$AUTOSTART_ENTRY" "$DESKTOP_FILE" 2>/dev/null; then
+    echo "Adding mpd-auto-stop to autostart..."
+
+    # Create the autostart entry
+    echo "[Desktop Entry]" > "$DESKTOP_FILE"
+    echo "Type=Application" >> "$DESKTOP_FILE"
+    echo "Exec=$AUTOSTART_ENTRY" >> "$DESKTOP_FILE"
+    echo "Name=mpd-auto-stop" >> "$DESKTOP_FILE"
+    echo "Comment=Starts mpd-auto-stop at login" >> "$DESKTOP_FILE"
+else
+    echo "mpd-auto-stop is already in autostart."
+fi
+
+echo "Installation complete! Please restart your shell or run:"
+echo "  source ~/.bashrc"
+echo "mpd-auto-stop is now configured to start on login."

--- a/mpd-auto-stop/install.sh
+++ b/mpd-auto-stop/install.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/bash
+
+# mpd-auto-stop installer chooser
+#
+# Prompts you to pick between install-xdg-autostart.sh and
+# install-systemd.sh (see their own headers, or README.md, for full
+# details), then runs the one you choose. Skip this and run either of
+# those two directly if you already know which one you want.
+
+set -e  # Exit on error
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+cd "$SCRIPT_DIR"
+
+cat <<'EOF'
+mpd-auto-stop can be installed one of two ways:
+
+  A) XDG autostart (default) -- a plain background process started via a
+     desktop autostart .desktop entry. Works on any desktop session, no
+     systemd required. Pick this unless you have a specific reason to
+     want B: it's simpler, and is the one to use on a minimal/embedded
+     setup or any session without a working `systemd --user`. If it
+     crashes, it stays down until your next login; logs go to its own
+     file (~/.local/state/mpd-auto-stop/mpd-auto-stop.log).
+
+  B) systemd --user service -- pick this if you want the daemon to
+     automatically restart if it crashes, or want its logs in
+     `journalctl` alongside your other services. Works headless too (e.g.
+     a Raspberry Pi with no desktop session) via `loginctl enable-linger`.
+
+EOF
+
+read -t 30 -r -p "Install via [A]utostart or [S]ystemd? (default: A, auto-selected in 30s) " choice || true
+echo
+
+case "${choice:-A}" in
+    [Ss]*) exec ./install-systemd.sh ;;
+    *)     exec ./install-xdg-autostart.sh ;;
+esac

--- a/mpd-auto-stop/mpd-auto-stop.conf.example
+++ b/mpd-auto-stop/mpd-auto-stop.conf.example
@@ -1,0 +1,52 @@
+# mpd-auto-stop configuration
+#
+# Copied to ~/.config/mpd-scripts/mpd-auto-stop/mpd-auto-stop.conf on first
+# run if that file doesn't already exist. Edit the copy there, not this
+# template.
+
+[mpd-auto-stop]
+
+# Address/port the web server itself listens on. Can be overridden per
+# invocation with -a/--http-host, -p/--http-port.
+http_host = 0.0.0.0
+http_port = 9090
+
+# Optional HTTP Basic Auth, since the server has no other access control
+# and listens on 0.0.0.0 by default -- anyone on the same network can
+# otherwise start/stop your timer. Leave both blank to disable (the
+# default). If set, every request (including the web UI itself) requires
+# these credentials. Can be overridden per invocation with
+# -U/--http-username, -W/--http-password.
+http_username =
+http_password =
+
+# MPD connection details. Can be overridden per invocation with
+# -H/--mpd-host, -P/--mpd-port, -w/--mpd-password.
+mpd_host = localhost
+mpd_port = 6600
+
+# Leave blank unless your MPD requires a password.
+mpd_password =
+
+# Seconds to fade the volume from its current level down to 0, ending
+# exactly when the timer would otherwise fire -- e.g. a 1h timer with
+# fade_duration=300 stays at full volume until 55 minutes in, then tapers
+# off over the last 5 minutes. Set to 0 to skip fading and pause instantly,
+# like the original tool this is based on. The volume is restored to its
+# pre-fade level right after pausing, so the next play isn't silently at 0.
+fade_duration = 300
+
+# Fire warning_hook this many seconds before the timer would fire (0
+# disables the warning entirely). Independent of fade_duration -- it
+# fires at its own configured offset regardless of whether that lands
+# before, during, or after the fade.
+warning_lead_time = 60
+
+# Optional shell commands. warning_hook runs warning_lead_time before the
+# timer fires; stop_hook runs right after playback is actually paused.
+# Leave blank to disable either. Useful for a desktop notification
+# (notify-send), a push notification (e.g. curl to ntfy.sh/your-topic), or
+# a home-automation webhook -- whatever fits a given machine, since this
+# is commonly run headless with no notification daemon of its own.
+warning_hook =
+stop_hook =

--- a/mpd-auto-stop/mpd-auto-stop.py
+++ b/mpd-auto-stop/mpd-auto-stop.py
@@ -1,0 +1,605 @@
+#!/usr/bin/env python3
+"""
+mpd-auto-stop
+
+A sleep-timer daemon for MPD: start a countdown (via a small HTTP API and
+web UI), and when it expires, fade the volume out and pause playback.
+Restart/extend an active timer, or cancel it outright.
+
+Endpoints:
+    GET /                          Web UI
+    GET /timer                     Status: {"status": "stopped"} or
+                                    {"status": "started", "remaining_seconds": N, "fading": bool}
+    GET /timer/<duration>/start    Start a timer. Duration like "45m", "1h", "1.5h", "3600s".
+    GET /timer/stop                Cancel the running timer (does not pause playback itself).
+    GET /timer/restart             Re-arm the running timer with its original duration.
+    GET /timer/<duration>/extend   Add more time to the running timer.
+
+Connection settings and behavior come from
+~/.config/mpd-scripts/mpd-auto-stop/mpd-auto-stop.conf, seeded from
+mpd-auto-stop.conf.example on first run.
+"""
+
+import argparse
+import base64
+import configparser
+import hmac
+import json
+import logging
+import os
+import re
+import signal
+import subprocess
+import sys
+import threading
+import urllib.parse as urlparse
+from datetime import datetime
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+from mpd import MPDClient
+from mpd import ConnectionError as MPDConnectionError
+
+VERSION = (2, 0, 0)
+
+CONFIG_DIR = os.path.join(os.path.expanduser("~"), ".config", "mpd-scripts", "mpd-auto-stop")
+CONFIG_FILE = os.path.join(CONFIG_DIR, "mpd-auto-stop.conf")
+
+STATE_DIR = os.path.join(os.path.expanduser("~"), ".local", "state", "mpd-auto-stop")
+PID_FILE = os.path.join(STATE_DIR, "mpd-auto-stop.pid")
+LOG_FILE = os.path.join(STATE_DIR, "mpd-auto-stop.log")
+
+DURATION_PATTERN = re.compile(r"^([0-9]*\.?[0-9]+)([smh])$")
+
+
+def parse_duration(duration: str) -> float:
+    """Parse a "45m"/"1h"/"1.5h"/"3600s"-style duration into seconds."""
+    duration = (duration or "").strip().lower()
+    match = DURATION_PATTERN.match(duration)
+    if not match:
+        raise ValueError(f"Invalid duration: {duration!r}")
+    value = float(match.group(1))
+    unit = match.group(2)
+    if unit == "m":
+        value *= 60
+    elif unit == "h":
+        value *= 3600
+    return value
+
+
+def load_config() -> configparser.SectionProxy:
+    """Load ~/.config/mpd-scripts/mpd-auto-stop/mpd-auto-stop.conf, seeding
+    it from the mpd-auto-stop.conf.example template shipped alongside this
+    script on first run.
+
+    Returns:
+        configparser.SectionProxy: the "mpd-auto-stop" section.
+    """
+    if not os.path.exists(CONFIG_FILE):
+        os.makedirs(CONFIG_DIR, mode=0o700, exist_ok=True)
+        template = os.path.join(os.path.dirname(os.path.abspath(__file__)), "mpd-auto-stop.conf.example")
+        with open(template) as src, open(CONFIG_FILE, "w") as dst:
+            dst.write(src.read())
+        os.chmod(CONFIG_FILE, 0o600)  # May contain an MPD password
+
+    config = configparser.ConfigParser()
+    config.read(CONFIG_FILE)
+    return config["mpd-auto-stop"]
+
+
+def check_permissions() -> None:
+    """Ensure STATE_DIR (holding the PID and log files) exists and is
+    writable, creating it if needed. Exits the process if it can't be."""
+    try:
+        os.makedirs(STATE_DIR, exist_ok=True)
+    except OSError as e:
+        print(f"Permission denied: cannot create {STATE_DIR}: {e}")
+        sys.exit(1)
+
+    if not os.access(STATE_DIR, os.W_OK):
+        print(f"Permission denied: cannot write to {STATE_DIR}.")
+        sys.exit(1)
+
+
+class InvalidTimerStateError(Exception):
+    pass
+
+
+class MPDConnection:
+    """Thread-safe wrapper around a single reused MPDClient connection.
+    Reconnects (once) on a dropped connection before giving up, since this
+    is a long-running daemon rather than a one-shot CLI call."""
+
+    def __init__(self, host: str, port: int, password: str = None):
+        self._host = host
+        self._port = port
+        self._password = password
+        self._client = MPDClient()
+        self._lock = threading.Lock()
+        self._connected = False
+
+    def _connect(self) -> None:
+        self._client = MPDClient()
+        self._client.connect(self._host, self._port)
+        if self._password:
+            self._client.password(self._password)
+        self._connected = True
+
+    def call(self, method_name: str, *args):
+        """Thread-safely invoke an MPDClient method by name, reconnecting
+        once on a dropped connection before letting the error propagate."""
+        with self._lock:
+            for attempt in (1, 2):
+                try:
+                    if not self._connected:
+                        self._connect()
+                    return getattr(self._client, method_name)(*args)
+                except (MPDConnectionError, OSError):
+                    self._connected = False
+                    if attempt == 2:
+                        raise
+
+
+class Hooks:
+    """Runs optional shell commands (warning_hook/stop_hook) from the
+    config, fire-and-forget. Never fatal -- a missing/broken hook shouldn't
+    affect the timer itself."""
+
+    def __init__(self, config: configparser.SectionProxy):
+        self._config = config
+
+    def run(self, name: str) -> None:
+        command = self._config.get(name, fallback="")
+        if not command:
+            return
+        try:
+            subprocess.Popen(command, shell=True)
+        except OSError:
+            pass
+
+
+class Timer:
+    """Sleep-timer state machine: start/stop/restart/extend a countdown
+    that fades the volume out and pauses playback when it reaches zero.
+
+    All public methods are safe to call concurrently from multiple HTTP
+    handler threads; the countdown/fade itself runs in its own background
+    thread so it never blocks request handling.
+    """
+
+    STOPPED = "stopped"
+    STARTED = "started"
+
+    def __init__(self, mpd: MPDConnection, config: configparser.SectionProxy, hooks: Hooks, logger: logging.Logger):
+        self._mpd = mpd
+        self._config = config
+        self._hooks = hooks
+        self._logger = logger
+        self._lock = threading.Lock()
+
+        self._status = Timer.STOPPED
+        self._started_at = None
+        self._duration = 0.0
+        self._fading = False
+        self._original_volume = None
+        self._cancel_event = None
+        self._thread = None
+
+    @property
+    def status(self) -> str:
+        return self._status
+
+    def _remaining_seconds(self) -> float:
+        elapsed = (datetime.now() - self._started_at).total_seconds()
+        return max(0.0, self._duration - elapsed)
+
+    def get_status(self) -> dict:
+        with self._lock:
+            result = {"status": self._status}
+            if self._status == Timer.STARTED:
+                result["remaining_seconds"] = round(self._remaining_seconds(), 1)
+                result["fading"] = self._fading
+            return result
+
+    def start(self, duration_str: str) -> dict:
+        duration = parse_duration(duration_str)
+        with self._lock:
+            if self._status == Timer.STARTED:
+                return {"remaining_seconds": round(self._remaining_seconds(), 1)}
+            self._begin(duration)
+            return {"remaining_seconds": round(self._remaining_seconds(), 1)}
+
+    def stop(self) -> dict:
+        with self._lock:
+            if self._status == Timer.STARTED:
+                self._cancel_run(restore_volume=True)
+                self._status = Timer.STOPPED
+                self._started_at = None
+                self._duration = 0.0
+                self._logger.info("Timer stopped")
+            return {}
+
+    def restart(self) -> dict:
+        with self._lock:
+            if self._status != Timer.STARTED:
+                raise InvalidTimerStateError("Can't restart a stopped timer")
+            duration = self._duration
+            self._cancel_run(restore_volume=True)
+            self._begin(duration)
+            self._logger.info("Timer restarted with duration %s seconds", duration)
+            return {"remaining_seconds": round(self._remaining_seconds(), 1)}
+
+    def extend(self, duration_str: str) -> dict:
+        with self._lock:
+            if self._status != Timer.STARTED:
+                raise InvalidTimerStateError("Can't extend a stopped timer")
+            new_duration = self._remaining_seconds() + parse_duration(duration_str)
+            self._cancel_run(restore_volume=True)
+            self._begin(new_duration)
+            self._logger.info("Timer extended with duration %s seconds", new_duration)
+            return {"remaining_seconds": round(self._remaining_seconds(), 1)}
+
+    # --- internal; callers must hold self._lock ---
+
+    def _begin(self, duration: float) -> None:
+        self._status = Timer.STARTED
+        self._started_at = datetime.now()
+        self._duration = duration
+        self._fading = False
+        self._original_volume = None
+        self._cancel_event = threading.Event()
+        self._thread = threading.Thread(target=self._run, args=(self._cancel_event, duration), daemon=True)
+        self._thread.start()
+        self._logger.info("Timer started with duration %s seconds", duration)
+
+    def _cancel_run(self, restore_volume: bool) -> None:
+        if self._cancel_event:
+            self._cancel_event.set()
+        if self._thread:
+            self._thread.join(timeout=5)
+        if restore_volume and self._fading and self._original_volume is not None:
+            try:
+                self._mpd.call("setvol", self._original_volume)
+            except Exception:
+                pass
+        self._fading = False
+        self._thread = None
+        self._cancel_event = None
+
+    def _run(self, cancel_event: threading.Event, duration: float) -> None:
+        """Wait out `duration`, running the warning hook and the fade at
+        their own independent offsets (whichever comes first), then pause.
+
+        The two are scheduled as absolute checkpoints and processed in
+        chronological order rather than chained sequentially, so this
+        stays correct regardless of which one is configured to happen
+        first -- with fade_duration > warning_lead_time (the shipped
+        default: fade starts before the warning fires), the fade's
+        remaining duration is clamped to whatever time is actually left,
+        so it always finishes exactly at `duration` instead of overrunning
+        it. Chaining these as "wait for warning, then wait for the rest of
+        fade_duration" only produced fade_duration itself -- not the
+        actual desired end time -- once the warning fired later than fade
+        should have already started.
+        """
+        fade_duration = max(0.0, self._config.getfloat("fade_duration", fallback=0.0))
+        warning_lead = max(0.0, self._config.getfloat("warning_lead_time", fallback=0.0))
+
+        checkpoints = []
+        if warning_lead > 0:
+            checkpoints.append((max(0.0, duration - warning_lead), "warning"))
+        if fade_duration > 0:
+            checkpoints.append((max(0.0, duration - fade_duration), "fade"))
+        checkpoints.sort(key=lambda checkpoint: checkpoint[0])
+
+        elapsed = 0.0
+        for offset, kind in checkpoints:
+            wait_time = offset - elapsed
+            if wait_time > 0:
+                if cancel_event.wait(timeout=wait_time):
+                    return
+                elapsed = offset
+
+            if kind == "warning":
+                self._hooks.run("warning_hook")
+            else:  # "fade" -- always run for exactly what's left until `duration`
+                if not self._do_fade(cancel_event, duration - elapsed):
+                    return
+                elapsed = duration
+
+        final_wait = duration - elapsed
+        if final_wait > 0:
+            if cancel_event.wait(timeout=final_wait):
+                return
+
+        self._do_stop_action()
+
+        with self._lock:
+            if self._cancel_event is cancel_event:  # not superseded by a restart/extend/stop meanwhile
+                self._status = Timer.STOPPED
+                self._started_at = None
+                self._duration = 0.0
+                self._fading = False
+                self._thread = None
+                self._cancel_event = None
+
+    def _do_fade(self, cancel_event: threading.Event, fade_seconds: float) -> bool:
+        """Ramp the volume down to 0 over fade_seconds seconds. Returns
+        False if cancelled partway through."""
+        try:
+            start_volume = int(self._mpd.call("status").get("volume", 0))
+        except Exception:
+            start_volume = 0
+
+        with self._lock:
+            self._original_volume = start_volume
+            self._fading = True
+
+        if start_volume <= 0 or fade_seconds <= 0:
+            return not cancel_event.is_set()
+
+        steps = max(1, int(fade_seconds))
+        tick_interval = fade_seconds / steps
+        for step in range(1, steps + 1):
+            if cancel_event.wait(timeout=tick_interval):
+                return False
+            target = max(0, round(start_volume * (1 - step / steps)))
+            try:
+                self._mpd.call("setvol", target)
+            except Exception:
+                pass
+        return True
+
+    def _do_stop_action(self) -> None:
+        try:
+            self._mpd.call("pause", 1)
+        except Exception as e:
+            self._logger.warning("Error pausing MPD: %s", e)
+        # Restore volume for next time now that playback is paused --
+        # otherwise the next play starts silently at 0.
+        if self._original_volume is not None:
+            try:
+                self._mpd.call("setvol", self._original_volume)
+            except Exception:
+                pass
+        self._logger.info("Timer fired, playback paused")
+        self._hooks.run("stop_hook")
+
+
+class Route:
+    __slots__ = ("pattern", "method_name")
+
+    def __init__(self, pattern: "re.Pattern", method_name: str):
+        self.pattern = pattern
+        self.method_name = method_name
+
+
+def build_handler_class(timer: Timer, index_html: str, logger: logging.Logger,
+                         http_username: str = "", http_password: str = ""):
+    routes = [
+        Route(re.compile(r"/?$"), "_index"),
+        Route(re.compile(r"/timer$"), "_timer_status"),
+        Route(re.compile(r"/timer/(?P<duration>[.0-9a-zA-Z]+)/start$"), "_timer_start"),
+        Route(re.compile(r"/timer/stop$"), "_timer_stop"),
+        Route(re.compile(r"/timer/restart$"), "_timer_restart"),
+        Route(re.compile(r"/timer/(?P<duration>[.0-9a-zA-Z]+)/extend$"), "_timer_extend"),
+    ]
+
+    auth_required = bool(http_username or http_password)
+    expected_header = "Basic " + base64.b64encode(f"{http_username}:{http_password}".encode()).decode()
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, fmt, *args):
+            logger.info("%s - %s", self.address_string(), fmt % args)
+
+        def _respond(self, status: int, content_type: str, body: str) -> None:
+            body_bytes = body.encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", content_type)
+            self.send_header("Content-Length", str(len(body_bytes)))
+            self.end_headers()
+            self.wfile.write(body_bytes)
+
+        def _json(self, status: int, obj: dict) -> None:
+            self._respond(status, "application/json", json.dumps(obj))
+
+        def _authenticated(self) -> bool:
+            if not auth_required:
+                return True
+            # Constant-time comparison so response timing can't leak how
+            # much of the credential was guessed correctly.
+            return hmac.compare_digest(self.headers.get("Authorization", ""), expected_header)
+
+        def _require_auth(self) -> None:
+            self.send_response(401)
+            self.send_header("WWW-Authenticate", 'Basic realm="mpd-auto-stop"')
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+
+        def do_GET(self):
+            if not self._authenticated():
+                self._require_auth()
+                return
+
+            path = urlparse.urlparse(self.path).path
+            for route in routes:
+                match = route.pattern.match(path)
+                if match:
+                    getattr(self, route.method_name)(match)
+                    return
+            self._respond(404, "text/plain", "Not found")
+
+        def _index(self, match):
+            self._respond(200, "text/html", index_html)
+
+        def _timer_status(self, match):
+            self._json(200, timer.get_status())
+
+        def _timer_start(self, match):
+            try:
+                self._json(200, timer.start(match.group("duration")))
+            except ValueError as e:
+                self._json(400, {"error": str(e)})
+            except Exception as e:
+                self._json(500, {"error": str(e)})
+
+        def _timer_stop(self, match):
+            try:
+                self._json(200, timer.stop())
+            except Exception as e:
+                self._json(500, {"error": str(e)})
+
+        def _timer_restart(self, match):
+            try:
+                self._json(200, timer.restart())
+            except InvalidTimerStateError as e:
+                self._json(400, {"error": str(e)})
+            except Exception as e:
+                self._json(500, {"error": str(e)})
+
+        def _timer_extend(self, match):
+            try:
+                self._json(200, timer.extend(match.group("duration")))
+            except (ValueError, InvalidTimerStateError) as e:
+                self._json(400, {"error": str(e)})
+            except Exception as e:
+                self._json(500, {"error": str(e)})
+
+    return Handler
+
+
+class App:
+    """The HTTP server itself. Uses the public serve_forever()/shutdown()
+    API (unlike the tool this is based on, which drove a private
+    _handle_request_noblock() method directly -- that bypassed the
+    select()-based wait serve_forever()/handle_request() rely on, so a
+    SIGTERM wouldn't actually stop the process until the next incoming
+    request happened to arrive)."""
+
+    def __init__(self, host: str, port: int, handler_class, logger: logging.Logger):
+        self._server = ThreadingHTTPServer((host, port), handler_class)
+        self._logger = logger
+
+    def run(self) -> None:
+        signal.signal(signal.SIGTERM, self._handle_signal)
+        signal.signal(signal.SIGINT, self._handle_signal)
+        self._logger.info("Starting server @ %s:%s", *self._server.server_address[:2])
+        self._server.serve_forever()
+        self._logger.info("Stopped.")
+
+    def _handle_signal(self, signum, frame) -> None:
+        self._logger.info("Received signal %s, stopping server...", signum)
+        # shutdown() blocks until serve_forever()'s loop exits, so it must
+        # run on a different thread than the one currently inside
+        # serve_forever() (this signal handler runs on that same thread).
+        threading.Thread(target=self._server.shutdown, daemon=True).start()
+
+
+def build_logger(verbose: bool) -> logging.Logger:
+    logger = logging.getLogger("mpd-auto-stop")
+    logger.setLevel(logging.DEBUG if verbose else logging.INFO)
+    if verbose:
+        handler = logging.StreamHandler()
+    else:
+        handler = logging.FileHandler(LOG_FILE)
+    handler.setFormatter(logging.Formatter("%(asctime)s - %(levelname)s - %(message)s"))
+    logger.addHandler(handler)
+    return logger
+
+
+def build_app(args: argparse.Namespace, config: configparser.SectionProxy, logger: logging.Logger) -> App:
+    mpd_host = args.mpd_host or config.get("mpd_host", fallback="localhost")
+    mpd_port = args.mpd_port or config.getint("mpd_port", fallback=6600)
+    mpd_password = args.mpd_password or config.get("mpd_password", fallback="") or None
+    http_host = args.http_host or config.get("http_host", fallback="0.0.0.0")
+    http_port = args.http_port or config.getint("http_port", fallback=9090)
+    http_username = args.http_username or config.get("http_username", fallback="")
+    http_password = args.http_password or config.get("http_password", fallback="")
+
+    mpd = MPDConnection(mpd_host, mpd_port, mpd_password)
+    hooks = Hooks(config)
+    timer = Timer(mpd, config, hooks, logger)
+
+    template_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "index.html")
+    with open(template_path) as f:
+        index_html = f.read()
+
+    handler_class = build_handler_class(timer, index_html, logger, http_username, http_password)
+    return App(http_host, http_port, handler_class, logger)
+
+
+def start_daemon(args: argparse.Namespace, config: configparser.SectionProxy) -> None:
+    """Forks the process, creates a new session, and runs the server in the
+    background, tracking its PID for later --stop."""
+    if os.path.exists(PID_FILE):
+        print("Daemon is already running.")
+        sys.exit(1)
+
+    pid = os.fork()
+    if pid > 0:
+        sys.exit(0)
+
+    os.setsid()
+    check_permissions()
+
+    with open(PID_FILE, "w") as f:
+        f.write(str(os.getpid()))
+
+    logger = build_logger(verbose=False)
+    app = build_app(args, config, logger)
+    app.run()
+    os.remove(PID_FILE)
+
+
+def stop_daemon() -> None:
+    """Sends SIGTERM to the PID recorded in PID_FILE, if it's still running."""
+    if not os.path.exists(PID_FILE):
+        print("Daemon is not running.")
+        sys.exit(1)
+
+    with open(PID_FILE) as f:
+        pid = int(f.read().strip())
+
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        print(f"No process found with PID {pid}. The daemon may have already stopped.")
+        os.remove(PID_FILE)
+        sys.exit(0)
+    except PermissionError:
+        print(f"Permission error while checking process with PID {pid}.")
+        sys.exit(1)
+
+    os.kill(pid, signal.SIGTERM)
+    print("Daemon stopped.")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="mpd-auto-stop: a sleep-timer daemon for MPD")
+    parser.add_argument("-a", "--http-host", default=None, help="Host to run the server on. Overrides mpd-auto-stop.conf.")
+    parser.add_argument("-p", "--http-port", default=None, type=int, help="Port for the server to listen on. Overrides mpd-auto-stop.conf.")
+    parser.add_argument("-H", "--mpd-host", default=None, help="MPD host. Overrides mpd-auto-stop.conf.")
+    parser.add_argument("-P", "--mpd-port", default=None, type=int, help="MPD port. Overrides mpd-auto-stop.conf.")
+    parser.add_argument("-w", "--mpd-password", default=None, help="MPD password. Overrides mpd-auto-stop.conf.")
+    parser.add_argument("-U", "--http-username", default=None, help="HTTP Basic Auth username. Overrides mpd-auto-stop.conf.")
+    parser.add_argument("-W", "--http-password", default=None, help="HTTP Basic Auth password. Overrides mpd-auto-stop.conf.")
+    parser.add_argument("-s", "--stop", action="store_true", help="Stop the daemon")
+    parser.add_argument("-v", "--verbose", action="store_true", help="Run in the foreground with console logging")
+    args = parser.parse_args()
+
+    if args.stop:
+        stop_daemon()
+        return
+
+    check_permissions()
+    config = load_config()
+
+    if args.verbose:
+        logger = build_logger(verbose=True)
+        app = build_app(args, config, logger)
+        app.run()
+    else:
+        start_daemon(args, config)
+
+
+if __name__ == "__main__":
+    main()

--- a/mpd-auto-stop/mpd-auto-stop.service
+++ b/mpd-auto-stop/mpd-auto-stop.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=mpd-auto-stop
+After=network.target sound.target
+
+[Service]
+# --verbose runs in the foreground with console logging instead of forking
+# and writing its own log/PID files, which is what systemd expects for
+# Type=simple; journald captures the console output.
+Type=simple
+ExecStart=%h/bin/mpd-auto-stop.py --verbose
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## Summary

Ports [vms20591/mpd_auto_stop](https://github.com/vms20591/mpd_auto_stop) from Python 2/3 + `mpc` subprocess calls to Python 3 + `python-mpd2`.

**Two bugs fixed from the original:**
- Every error-response path called the Python 2-only `exp.message` attribute, removed in Python 3, so every error path raised an unhandled `AttributeError` instead of returning the intended JSON error body.
- The server drove a private `_handle_request_noblock()` method directly instead of the public `serve_forever()`/`shutdown()` API, so a `SIGTERM` (e.g. `systemctl stop`) wouldn't actually take effect until the next incoming request happened to arrive.

**Added on top of the original's bare JSON API and link list:**
- Fade-out ending exactly when the timer would otherwise fire, clamped so a misconfigured `fade_duration` can't push the actual stop time later than requested.
- Optional `warning_hook`/`stop_hook` shell commands (desktop notification, push notification, home-automation webhook, etc.) — since this commonly runs headless with no notification daemon of its own.
- Optional HTTP Basic Auth (`http_username`/`http_password`, blank = disabled), since the server has no other access control and listens on `0.0.0.0` by default.
- A web UI: preset duration buttons, live countdown, light/dark/auto theme (soft grays, not pure black/white), all vanilla JS/CSS with zero new dependencies.
- Registered in the top-level README and `install.sh`.

**A third bug was introduced and fixed during this port's own development**: the warning and fade were originally chained sequentially, which only produced correct timing when `warning_lead_time > fade_duration`. The shipped defaults are the opposite ratio (`fade_duration=300` > `warning_lead_time=60`), so it actually ran timers past their requested duration. Fixed by scheduling both as independent absolute-offset checkpoints, with the fade always clamped to whatever time is actually left.

## Test plan
- [x] `python3 -m py_compile` and all shell installers `bash -n`
- [x] Full `Timer` state machine (start/stop/restart/extend, error states) verified against a mocked MPD connection
- [x] Fade-to-pause cycle, volume restore, and cancel-mid-fade-restores-immediately all verified
- [x] The sequencing bug reproduced against a scaled-down version of the shipped default ratio, then reverified as fixed (fade start and pause timing both landed exactly on target, down from a 20% overrun)
- [x] Misconfigured `fade_duration` longer than the timer itself confirmed to clamp rather than overrun
- [x] Full HTTP layer tested against a real running server (actual `urllib` requests, not mocked): all routes, clean 400/404 JSON error bodies (not raw tracebacks), and graceful shutdown via the public API not deadlocking
- [x] HTTP Basic Auth tested end-to-end: disabled by default, 401 + `WWW-Authenticate` challenge, wrong credentials rejected, correct credentials pass, index page protected too
- [x] Config seeding, `0600` permissions, and CLI help output checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)