### PR TITLE
Add mpd-random-album: replace queue with random complete albums

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Collection of scripts related to mpd & mpc.
 | **[rm-artists-playlist](./rm-artists-playlist/)** | Removes songs by a list of artists from a saved MPD playlist or the current queue, or lists available playlists. |
 | **[mpd-add-random-artist](./mpd-add-random-artist/)** | Adds a random sample of a specified artist's tracks to the current MPD queue, matching exactly by default or loosely with `-l`. |
 | **[mpd-add-random](./mpd-add-random/)** | Adds a random selection of tracks from the local music library to the current MPD queue. |
+| **[mpd-random-album](./mpd-random-album/)** | Clears the queue and replaces it with randomly selected complete albums, saving and restoring the original queue/state if anything fails. |
 | **[add-current-song](./add-current-song/)** | Adds the currently playing MPD song to an M3U playlist, with duplicate prevention, sorting, locking, and atomic rewrites. |
 | **[mpd-tray-icon](./mpd-tray-icon/)** | A GTK3 tray icon showing the currently playing MPD track, with Play/Pause/Next/Previous controls. |
 | **[mpd-radio-tray](./mpd-radio-tray/)** | A PyQt5 system tray app for managing and playing categorized internet radio station URLs with MPD, similar to RadioTray-NG. |

--- a/install.sh
+++ b/install.sh
@@ -288,6 +288,7 @@ SIMPLE_SCRIPTS=(
     "mpd-find-dup|mpd-remove-duplicates-queue.sh mpd-deduplicate-save-and-reload.sh|mpd-deduplicate-save-and-reload.conf.example"
     "mpd-queue-shuffle|mpd-queue-shuffle.sh|mpd-queue-shuffle.conf.example"
     "mpd-radio-tray|mpd-radio-tray.py|mpd-radio-tray.conf.example stations.txt.example"
+    "mpd-random-album|mpd-random-album.sh|mpd-random-album.conf.example"
     "mpd-recent-tracks|mpd-recent-tracks.sh|mpd-recent-tracks.conf.example exclude_paths.txt.example"
     "mpdsimilar|mpdsimilar.sh|mpdsimilar.conf.example"
     "mpd-tray-icon|mpd-tray-icon.py|"

--- a/mpd-random-album/README.md
+++ b/mpd-random-album/README.md
@@ -1,0 +1,65 @@
+# mpd-random-album
+
+Clears the current MPD queue and replaces it with a randomly selected collection of complete albums, then starts playback.
+
+## Features
+
+- Selects random unique album/album-artist combinations, using exact matching (`mpc find`, not `mpc search`) so similarly-named albums (e.g. `The Wall` vs. `The Wall (Remastered)`) don't get conflated
+- Resolves every selected album *before* touching the existing queue -- nothing is modified until the whole selection succeeds (or degrades gracefully with `--force`)
+- Saves the original queue and playback state (random/repeat/single/consume, play state, song position) beforehand, and restores it automatically if anything fails partway through
+- Verifies the resulting queue actually contains what was intended before starting playback
+- Dry-run mode to preview what would be selected without changing anything
+- Distinct exit codes for scripting: `0` full success, `2` partial success, `1` failure, `130`/`143` on interrupt/terminate
+
+## Requirements
+
+- `mpc`
+- `awk`, `shuf` (standard on virtually all Linux distros)
+
+## Usage
+
+```bash
+mpd-random-album.sh [OPTIONS] [ALBUM_COUNT]
+```
+
+| Option | Description |
+| --- | --- |
+| `-d`, `--dry-run` | Select and resolve albums without changing the queue |
+| `-f`, `--force` | Skip albums that fail to resolve instead of aborting the run |
+| `-q`, `--quiet` | Suppress informational messages |
+| `-h`, `--help` | Show help |
+
+`ALBUM_COUNT` defaults to `DEFAULT_ALBUM_COUNT` from the config file if not given.
+
+### Examples
+
+```bash
+mpd-random-album.sh              # one random album
+mpd-random-album.sh 5             # five random albums
+mpd-random-album.sh --quiet 3
+mpd-random-album.sh --dry-run 10
+mpd-random-album.sh --force 5     # don't abort if one of the 5 has vanished from the library
+```
+
+## Configuration
+
+Settings live in `~/.config/mpd-scripts/mpd-random-album/mpd-random-album.conf`, seeded automatically from [`mpd-random-album.conf.example`](./mpd-random-album.conf.example) the first time you run the script. Edit the copy there, not the template.
+
+| Setting | Description | Default |
+| --- | --- | --- |
+| `DEFAULT_ALBUM_COUNT` | Number of albums selected when `ALBUM_COUNT` isn't given | `1` |
+| `QUIET` | Suppress informational messages by default | `false` |
+| `DRY_RUN` | Select/resolve without changing the queue, by default | `false` |
+| `FORCE` | Skip failed albums instead of aborting, by default | `false` |
+
+Each setting can still be overridden per invocation with its corresponding flag.
+
+## Behavior on album resolution failure
+
+By default, if a selected album can't be resolved (e.g. it was removed from the library between selection and resolution), the run **aborts** and the original queue/state is restored -- nothing is left half-changed. Pass `--force` (or set `FORCE=true` in the config) to skip unresolvable albums instead and continue with whatever did resolve, exiting `2` if that means fewer albums were added than requested.
+
+## License
+
+This project is licensed under the **GNU General Public License v3.0**.
+
+See [LICENSE](../LICENSE) for more information.

--- a/mpd-random-album/mpd-random-album.conf.example
+++ b/mpd-random-album/mpd-random-album.conf.example
@@ -1,0 +1,28 @@
+# mpd-random-album.conf
+#
+# Copied to
+# ~/.config/mpd-scripts/mpd-random-album/mpd-random-album.conf on first run
+# if that file doesn't already exist. Edit the copy there, not this
+# template.
+
+# Number of albums selected when no count is supplied on the command line.
+DEFAULT_ALBUM_COUNT=1
+
+# Suppress informational messages by default.
+# true  = quiet by default
+# false = show status messages by default
+# Can be overridden per invocation with -q/--quiet.
+QUIET=false
+
+# Select and resolve albums without changing the MPD queue, by default.
+# true  = dry-run by default
+# false = actually replace the queue by default
+# Can be overridden per invocation with -d/--dry-run.
+DRY_RUN=false
+
+# Skip albums that fail to resolve (e.g. removed from the library between
+# selection and resolution) instead of aborting the whole run, by default.
+# true  = skip failed albums and continue by default
+# false = abort on the first album that fails to resolve, by default
+# Can be overridden per invocation with -f/--force.
+FORCE=false

--- a/mpd-random-album/mpd-random-album.sh
+++ b/mpd-random-album/mpd-random-album.sh
@@ -1,0 +1,766 @@
+#!/usr/bin/bash
+# shellcheck disable=SC2317
+
+#
+# Script: mpd-random-album.sh
+#
+# Note: SC2317 ("unreachable" code) is disabled file-wide above because the
+# static analysis doesn't trace functions that are only ever invoked via
+# `trap` (restore_queue, handle_error, handle_signal, handle_int,
+# handle_term, cleanup) -- it otherwise flags their bodies as unreachable
+# even though they're the script's actual error/signal/exit handlers.
+#
+# Purpose:
+#   Clear the current MPD queue and replace it with a randomly selected
+#   collection of complete albums, then begin playback.
+#
+# Behavior:
+#   - Selects random unique album/album-artist combinations.
+#   - Uses exact album and album-artist matching when resolving albums.
+#   - Resolves every selected album before modifying the queue.
+#   - Skips albums that disappear from the library between selection and
+#     resolution when --force is given; aborts the run otherwise.
+#   - Saves the original MPD queue and playback state before modification.
+#   - Restores the original queue and state if an error occurs after the
+#     queue has been modified.
+#   - Verifies the resulting queue before playback.
+#   - Returns 0 for complete success, 2 for partial success, 1 for failure,
+#     130 for SIGINT, and 143 for SIGTERM.
+#
+# Usage:
+#   mpd-random-album.sh [OPTIONS] [ALBUM_COUNT]
+#
+# Examples:
+#   mpd-random-album.sh
+#   mpd-random-album.sh 5
+#   mpd-random-album.sh --quiet 3
+#   mpd-random-album.sh --dry-run 10
+#
+
+set -Eeuo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+# Settings live in
+# ~/.config/mpd-scripts/mpd-random-album/mpd-random-album.conf, seeded from
+# the mpd-random-album.conf.example template shipped alongside this script
+# on first run. Edit the copy there, not the template.
+CONFIG_DIR="$HOME/.config/mpd-scripts/mpd-random-album"
+CONFIG_FILE="$CONFIG_DIR/mpd-random-album.conf"
+
+if [[ ! -f "$CONFIG_FILE" ]]; then
+    mkdir -p "$CONFIG_DIR"
+    cp "$(dirname "$0")/mpd-random-album.conf.example" "$CONFIG_FILE"
+fi
+
+# shellcheck source=mpd-random-album.conf.example
+source "$CONFIG_FILE"
+
+# ---------------------------------------------------------------------------
+# Runtime state
+# ---------------------------------------------------------------------------
+
+QUEUE_MODIFIED=false
+RESTORING_QUEUE=false
+HANDLING_ERROR=false
+
+ORIGINAL_RANDOM=""
+ORIGINAL_REPEAT=""
+ORIGINAL_SINGLE=""
+ORIGINAL_CONSUME=""
+ORIGINAL_STATE=""
+ORIGINAL_SONG_POSITION=""
+
+declare -a ORIGINAL_QUEUE=()
+declare -a RANDOM_ALBUMS=()
+declare -a RESOLVED_ALBUMS=()
+declare -a SELECTED_TRACKS=()
+
+# ---------------------------------------------------------------------------
+# Logging and error handling
+# ---------------------------------------------------------------------------
+
+log_message() {
+    if [[ "$QUIET" != true ]]; then
+        printf '%s\n' "$*"
+    fi
+}
+
+warning_message() {
+    printf 'Warning: %s\n' "$*" >&2
+}
+
+#
+# Restore the original MPD queue and playback state.
+#
+# Restoration deliberately ignores individual MPD failures. We are already
+# recovering from an error, so another restoration failure must not trigger
+# recursive ERR handling.
+#
+restore_queue() {
+    local track
+    local restore_position=""
+
+    if [[ "$RESTORING_QUEUE" == true ]]; then
+        return 0
+    fi
+
+    RESTORING_QUEUE=true
+
+    #
+    # Disable the ERR trap during restoration. Every MPD command also uses
+    # "|| true" so a failed restoration command cannot recursively invoke
+    # the error handler.
+    #
+    trap - ERR
+
+    mpc stop >/dev/null 2>&1 || true
+    mpc clear >/dev/null 2>&1 || true
+
+    if [[ ${#ORIGINAL_QUEUE[@]} -gt 0 ]]; then
+        for track in "${ORIGINAL_QUEUE[@]}"; do
+            mpc add -- "$track" >/dev/null 2>&1 || true
+        done
+    fi
+
+    # Restore random playback state.
+    case "$ORIGINAL_RANDOM" in
+        on)
+            mpc random on >/dev/null 2>&1 || true
+            ;;
+        off)
+            mpc random off >/dev/null 2>&1 || true
+            ;;
+    esac
+
+    # Restore repeat state.
+    case "$ORIGINAL_REPEAT" in
+        on)
+            mpc repeat on >/dev/null 2>&1 || true
+            ;;
+        off)
+            mpc repeat off >/dev/null 2>&1 || true
+            ;;
+    esac
+
+    # "single" and "consume" support "once" in addition to on/off.
+    case "$ORIGINAL_SINGLE" in
+        on)
+            mpc single on >/dev/null 2>&1 || true
+            ;;
+        off)
+            mpc single off >/dev/null 2>&1 || true
+            ;;
+        once)
+            mpc single once >/dev/null 2>&1 || true
+            ;;
+    esac
+
+    case "$ORIGINAL_CONSUME" in
+        on)
+            mpc consume on >/dev/null 2>&1 || true
+            ;;
+        off)
+            mpc consume off >/dev/null 2>&1 || true
+            ;;
+        once)
+            mpc consume once >/dev/null 2>&1 || true
+            ;;
+    esac
+
+    if [[ ${#ORIGINAL_QUEUE[@]} -eq 0 ]]; then
+        #
+        # The original queue was empty, so leaving MPD stopped with an empty
+        # queue is the correct restored state.
+        #
+        mpc stop >/dev/null 2>&1 || true
+    elif [[ -n "$ORIGINAL_SONG_POSITION" ]]; then
+        restore_position="$ORIGINAL_SONG_POSITION"
+
+        case "$ORIGINAL_STATE" in
+            playing)
+                mpc play "$restore_position" >/dev/null 2>&1 || true
+                ;;
+            paused)
+                mpc play "$restore_position" >/dev/null 2>&1 || true
+                mpc pause >/dev/null 2>&1 || true
+                ;;
+            stopped)
+                mpc stop >/dev/null 2>&1 || true
+                ;;
+        esac
+    fi
+
+    QUEUE_MODIFIED=false
+    RESTORING_QUEUE=false
+
+    trap handle_error ERR
+}
+
+#
+# Print an error message and restore the original MPD state if necessary.
+#
+# IMPORTANT:
+# Explicit exit calls do not trigger the ERR trap. Therefore restoration
+# must happen here rather than relying exclusively on handle_error().
+#
+# The ERR trap remains as a second line of defense for unhandled failures.
+#
+error_exit() {
+    local message="$*"
+
+    if [[ "$QUEUE_MODIFIED" == true &&
+          "$RESTORING_QUEUE" != true &&
+          "$HANDLING_ERROR" != true ]]; then
+        HANDLING_ERROR=true
+        restore_queue || true
+        HANDLING_ERROR=false
+    fi
+
+    printf 'Error: %s\n' "$message" >&2
+    exit 1
+}
+
+#
+# Handle unhandled command failures.
+#
+handle_error() {
+    local exit_code=$?
+
+    if [[ "$HANDLING_ERROR" == true ]]; then
+        return "$exit_code"
+    fi
+
+    HANDLING_ERROR=true
+
+    if [[ "$QUEUE_MODIFIED" == true &&
+          "$RESTORING_QUEUE" != true ]]; then
+        restore_queue || true
+    fi
+
+    printf 'Error: An unexpected error occurred.\n' >&2
+
+    HANDLING_ERROR=false
+
+    return "$exit_code"
+}
+
+# ---------------------------------------------------------------------------
+# Signal handling
+# ---------------------------------------------------------------------------
+
+handle_signal() {
+    local signal="$1"
+    local exit_code
+
+    case "$signal" in
+        INT)
+            exit_code=130
+            ;;
+        TERM)
+            exit_code=143
+            ;;
+        *)
+            exit_code=1
+            ;;
+    esac
+
+    if [[ "$QUEUE_MODIFIED" == true &&
+          "$RESTORING_QUEUE" != true ]]; then
+        log_message "Interrupted; restoring the original MPD queue..."
+        restore_queue || true
+    fi
+
+    exit "$exit_code"
+}
+
+handle_int() {
+    handle_signal INT
+}
+
+handle_term() {
+    handle_signal TERM
+}
+
+trap handle_error ERR
+trap handle_int INT
+trap handle_term TERM
+
+# ---------------------------------------------------------------------------
+# Cleanup
+# ---------------------------------------------------------------------------
+
+cleanup() {
+    #
+    # Album selection uses process substitution rather than a persistent
+    # temporary file, so there is currently nothing to remove here.
+    #
+    :
+}
+
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Dependency checking
+# ---------------------------------------------------------------------------
+
+check_dependencies() {
+    local command_name
+
+    # Keep dependencies alphabetically ordered.
+    for command_name in awk mpc shuf; do
+        if ! command -v "$command_name" >/dev/null 2>&1; then
+            error_exit "Required command not found: $command_name"
+        fi
+    done
+}
+
+# ---------------------------------------------------------------------------
+# Argument handling
+# ---------------------------------------------------------------------------
+
+show_help() {
+    cat <<'EOF'
+Usage:
+  mpd-random-album.sh [OPTIONS] [ALBUM_COUNT]
+
+Description:
+  Replace the current MPD queue with randomly selected complete albums.
+
+Options:
+  -d, --dry-run    Select and resolve albums without changing the queue.
+  -f, --force      Skip albums that fail to resolve instead of aborting.
+  -h, --help       Show this help message.
+  -q, --quiet      Suppress informational messages.
+
+Arguments:
+  ALBUM_COUNT      Number of albums to select. Defaults to 1.
+
+Exit codes:
+  0   All requested albums were added successfully.
+  1   General failure.
+  2   Some albums could not be added (only possible with --force).
+  130 Interrupted with SIGINT.
+  143 Terminated with SIGTERM.
+EOF
+}
+
+parse_arguments() {
+    local album_count_set=false
+
+    ALBUM_COUNT="$DEFAULT_ALBUM_COUNT"
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -d|--dry-run)
+                DRY_RUN=true
+                shift
+                ;;
+            -f|--force)
+                FORCE=true
+                shift
+                ;;
+            -h|--help)
+                show_help
+                exit 0
+                ;;
+            -q|--quiet)
+                QUIET=true
+                shift
+                ;;
+            --)
+                shift
+                break
+                ;;
+            -*)
+                error_exit "Unknown option: $1"
+                ;;
+            *)
+                if [[ "$album_count_set" == true ]]; then
+                    error_exit "Too many arguments."
+                fi
+
+                ALBUM_COUNT="$1"
+                album_count_set=true
+                shift
+                ;;
+        esac
+    done
+
+    if [[ $# -gt 0 ]]; then
+        error_exit "Unexpected argument: $1"
+    fi
+
+    if ! [[ "$ALBUM_COUNT" =~ ^[1-9][0-9]*$ ]]; then
+        error_exit "Album count must be a positive integer."
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# MPD state handling
+# ---------------------------------------------------------------------------
+
+save_mpd_state() {
+    local status_line
+    local queue_output
+
+    if ! status_line="$(
+        mpc status \
+            --format='%random%\t%repeat%\t%single%\t%consume%\t%state%\t%songpos%'
+    )"; then
+        error_exit "Unable to read MPD status."
+    fi
+
+    if [[ -z "$status_line" ]]; then
+        error_exit "MPD returned an empty status."
+    fi
+
+    IFS=$'\t' read -r \
+        ORIGINAL_RANDOM \
+        ORIGINAL_REPEAT \
+        ORIGINAL_SINGLE \
+        ORIGINAL_CONSUME \
+        ORIGINAL_STATE \
+        ORIGINAL_SONG_POSITION <<< "$status_line"
+
+    if [[ -n "$ORIGINAL_SONG_POSITION" &&
+          "$ORIGINAL_SONG_POSITION" != "-" ]]; then
+
+        if ! [[ "$ORIGINAL_SONG_POSITION" =~ ^[0-9]+$ ]]; then
+            error_exit \
+                "Unexpected MPD song position: $ORIGINAL_SONG_POSITION"
+        fi
+
+        #
+        # %songpos% is zero-based, while "mpc play POSITION" is one-based.
+        # Convert it here so restoration can use the stored value directly.
+        #
+        ORIGINAL_SONG_POSITION=$((ORIGINAL_SONG_POSITION + 1))
+    else
+        ORIGINAL_SONG_POSITION=""
+    fi
+
+    if ! queue_output="$(mpc playlist)"; then
+        error_exit "Unable to save the current MPD queue."
+    fi
+
+    ORIGINAL_QUEUE=()
+
+    if [[ -n "$queue_output" ]]; then
+        mapfile -t ORIGINAL_QUEUE <<< "$queue_output"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Queue verification
+# ---------------------------------------------------------------------------
+
+verify_queue() {
+    local queue_output
+    local count
+    local -a queue_lines=()
+
+    #
+    # Do not use %length% here.
+    #
+    # %length% represents duration, not the number of tracks in the queue.
+    # Counting mpc playlist output gives the actual number of queued songs.
+    #
+    if ! queue_output="$(mpc playlist)"; then
+        error_exit "Unable to read MPD queue; MPD may be unavailable."
+    fi
+
+    count=0
+
+    if [[ -n "$queue_output" ]]; then
+        mapfile -t queue_lines <<< "$queue_output"
+        count=${#queue_lines[@]}
+    fi
+
+    if ! [[ "$count" =~ ^[0-9]+$ ]]; then
+        error_exit "Unexpected queue count: $count"
+    fi
+
+    printf '%s' "$count"
+}
+
+# ---------------------------------------------------------------------------
+# Album record validation
+# ---------------------------------------------------------------------------
+
+count_tabs() {
+    local value="$1"
+    local original_length
+    local stripped_length
+
+    original_length=${#value}
+
+    # Remove all tabs using Bash parameter expansion.
+    value="${value//$'\t'/}"
+
+    stripped_length=${#value}
+
+    printf '%s' "$((original_length - stripped_length))"
+}
+
+validate_album_record() {
+    local album_record="$1"
+    local tab_count
+
+    tab_count="$(count_tabs "$album_record")"
+
+    if (( tab_count != 1 )); then
+        error_exit \
+            "Malformed album record (expected exactly one tab): $album_record"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Album selection
+# ---------------------------------------------------------------------------
+
+select_random_albums() {
+    local album_count="$1"
+    local album_record
+
+    RANDOM_ALBUMS=()
+
+    mapfile -t RANDOM_ALBUMS < <(
+        mpc listall --format='%albumartist%\t%album%' |
+            awk -F '\t' '
+                NF == 2 &&
+                $1 != "" &&
+                $2 != "" {
+                    print $1 "\t" $2
+                }
+            ' |
+            sort -u |
+            shuf -n "$album_count"
+    )
+
+    if [[ ${#RANDOM_ALBUMS[@]} -eq 0 ]]; then
+        error_exit "No valid albums were found in the MPD library."
+    fi
+
+    for album_record in "${RANDOM_ALBUMS[@]}"; do
+        validate_album_record "$album_record"
+    done
+}
+
+# ---------------------------------------------------------------------------
+# Album resolution
+# ---------------------------------------------------------------------------
+
+resolve_albums() {
+    local album_record
+    local album_artist
+    local album
+    local track
+    local album_track_count
+    local -a album_tracks
+
+    RESOLVED_ALBUMS=()
+    SELECTED_TRACKS=()
+
+    for album_record in "${RANDOM_ALBUMS[@]}"; do
+        album_artist="${album_record%%$'\t'*}"
+        album="${album_record#*$'\t'}"
+
+        #
+        # Use mpc find rather than mpc search because the selected album and
+        # album artist must match exactly.
+        #
+        # mpc search can produce unintended matches when metadata contains
+        # similar names, such as:
+        #
+        #   The Wall
+        #   The Wall (Remastered)
+        #
+        # The exact metadata pair selected above should resolve to exactly
+        # that album rather than to substring/partial matches.
+        #
+        mapfile -t album_tracks < <(
+            mpc find album "$album" albumartist "$album_artist"
+        )
+
+        album_track_count=0
+
+        if [[ ${#album_tracks[@]} -eq 0 ]]; then
+            if [[ "$FORCE" != true ]]; then
+                error_exit \
+                    "No tracks found for: $album_artist - $album (use --force to skip albums that fail to resolve instead of aborting)"
+            fi
+
+            warning_message "No tracks found for: $album_artist - $album"
+            continue
+        fi
+
+        for track in "${album_tracks[@]}"; do
+            if [[ -n "$track" ]]; then
+                SELECTED_TRACKS+=("$track")
+
+                #
+                # Safe with set -e: the result is 1, 2, 3... rather than 0.
+                #
+                ((album_track_count += 1))
+            fi
+        done
+
+        if (( album_track_count == 0 )); then
+            if [[ "$FORCE" != true ]]; then
+                error_exit \
+                    "Album contains no valid tracks: $album_artist - $album (use --force to skip albums that fail to resolve instead of aborting)"
+            fi
+
+            warning_message "Album contains no valid tracks: $album_artist - $album"
+            continue
+        fi
+
+        RESOLVED_ALBUMS+=("$album_record")
+
+        log_message \
+            "Resolved: $album_artist - $album ($album_track_count track(s))"
+    done
+
+    if [[ ${#RESOLVED_ALBUMS[@]} -eq 0 ]]; then
+        error_exit "None of the selected albums could be resolved."
+    fi
+
+    if [[ ${#SELECTED_TRACKS[@]} -eq 0 ]]; then
+        error_exit "No tracks were resolved from the selected albums."
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Queue modification
+# ---------------------------------------------------------------------------
+
+clear_and_fill_queue() {
+    local track
+
+    if ! mpc clear >/dev/null; then
+        error_exit "Unable to clear the MPD queue."
+    fi
+
+    QUEUE_MODIFIED=true
+
+    #
+    # Random playback is disabled while constructing the queue.
+    # The original random state is restored after the queue is verified.
+    #
+    if ! mpc random off >/dev/null; then
+        error_exit "Unable to disable MPD random playback."
+    fi
+
+    for track in "${SELECTED_TRACKS[@]}"; do
+        if ! mpc add -- "$track" >/dev/null; then
+            error_exit "Unable to add track to MPD queue: $track"
+        fi
+    done
+}
+
+# ---------------------------------------------------------------------------
+# Final validation and playback
+# ---------------------------------------------------------------------------
+
+start_playback() {
+    local queue_length
+
+    queue_length="$(verify_queue)"
+
+    if (( queue_length != ${#SELECTED_TRACKS[@]} )); then
+        error_exit \
+            "Queue verification failed: expected ${#SELECTED_TRACKS[@]} track(s), found $queue_length."
+    fi
+
+    #
+    # Report albums added, not tracks. Each album may contain multiple tracks.
+    #
+    log_message \
+        "Added ${#RESOLVED_ALBUMS[@]} random album(s) containing $queue_length track(s)."
+
+    if ! mpc play >/dev/null; then
+        error_exit "Unable to start MPD playback."
+    fi
+
+    #
+    # Restore the original random setting only after the new queue has been
+    # successfully built and playback has started.
+    #
+    case "$ORIGINAL_RANDOM" in
+        on)
+            if ! mpc random on >/dev/null; then
+                error_exit "Unable to restore MPD random playback state."
+            fi
+            ;;
+        off)
+            if ! mpc random off >/dev/null; then
+                error_exit "Unable to restore MPD random playback state."
+            fi
+            ;;
+    esac
+
+    QUEUE_MODIFIED=false
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+main() {
+    local requested_album_count
+    local resolved_album_count
+
+    check_dependencies
+    parse_arguments "$@"
+
+    requested_album_count="$ALBUM_COUNT"
+
+    save_mpd_state
+
+    # Resolve everything before changing the user's existing queue.
+    select_random_albums "$requested_album_count"
+    resolve_albums
+
+    resolved_album_count="${#RESOLVED_ALBUMS[@]}"
+
+    if [[ "$DRY_RUN" == true ]]; then
+        log_message \
+            "Dry run: $resolved_album_count album(s) resolved; MPD queue was not changed."
+
+        return 0
+    fi
+
+    clear_and_fill_queue
+    start_playback
+
+    if (( resolved_album_count < requested_album_count )); then
+        warning_message \
+            "Only $resolved_album_count of $requested_album_count requested album(s) were added."
+
+        return 2
+    fi
+
+    log_message "Playback started successfully."
+
+    return 0
+}
+
+#
+# main is invoked via "|| exit_code=$?" rather than as a bare command.
+#
+# Why:
+#   set -e/-E treat ANY non-zero return from a top-level command as a
+#   failure that trips the ERR trap -- including main's own deliberate
+#   "return 2" for partial success. A bare "main "$@"" would print the
+#   generic "An unexpected error occurred." message even on a successful,
+#   documented partial-success run. Making main's invocation part of a "||"
+#   list exempts it from that (per bash's set -e rules: a command
+#   immediately followed by "||" doesn't trigger errexit/ERR on failure),
+#   so only genuinely unhandled errors inside main still reach the trap.
+#
+exit_code=0
+main "$@" || exit_code=$?
+exit "$exit_code"


### PR DESCRIPTION
## Summary

Adds a user-provided script that clears the MPD queue and refills it with randomly selected complete albums, with state save/restore, exact album matching, and queue verification throughout.

**Two real bugs fixed, both confirmed with a fake `mpc` harness before and after:**
- `main`'s own deliberate `return 2` (partial success) tripped `set -e`'s ERR trap the same way a genuine failure would, since `main "$@"` was a bare top-level command and `return` isn't exempt the way explicit `exit` calls are. Every partial-success run printed a spurious `Error: An unexpected error occurred.` right after its correct warning. Fixed by invoking `main` via `|| exit_code=$?`, which bash exempts from errexit/ERR.
- `--force` was a no-op: every code path already skipped an unresolvable album and continued regardless of the flag, so "continue when resolution fails" was already the unconditional default with nothing left for `--force` to gate. Changed the default to abort the run (restoring the saved queue/state) on the first unresolvable album, with `--force` now the thing that opts into skip-and-continue.

**Smaller fixes:** missing `local` declarations on two loop variables, an unused `mktemp` dependency check, the shebang, and configuration moved into `~/.config/mpd-scripts/mpd-random-album/mpd-random-album.conf` (seeded from `mpd-random-album.conf.example`) matching this repo's convention. Registered in the top-level README and `install.sh`.

## Test plan
- [x] `shellcheck` clean (required a documented file-wide `SC2317` disable, since its reachability analysis can't trace functions only invoked via `trap`)
- [x] Fake `mpc` harness: confirmed the spurious error message is gone from the partial-success path while the exit code stays correct
- [x] Confirmed `--force` now genuinely changes behavior (abort-with-restore vs. skip-and-continue), verified against the exact same failure scenario with and without the flag
- [x] Full-success and dry-run paths reverified unaffected
- [x] Config auto-seeding and `--help` verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)