### PR TITLE
Add mpd-usb-automount: stable-name + on-demand mount for a USB music disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Collection of scripts related to mpd & mpc.
 | **[somafm](./somafm/)** | This script fetches the playlist URLs of SomaFM channels with the highest quality in MP3 format and creates separate playlists for each channel in extended M3U format with the channel name. |
 | **[mpd-find-dup](./mpd-find-dup/)** | Contains two scripts for deduplicating MPD queues: `mpd-remove-duplicates-queue.sh` interactively deletes duplicates from the current MPD playlist in-place, while `mpd-deduplicate-save-and-reload.sh` saves the current queue as a playlist, removes duplicates, then reloads the cleaned playlist. |
 | **[mpd_rewind_daemon](./mpd_rewind_daemon/)** | A background daemon for MPD that automatically rewinds playback by a few seconds when resuming from pause, improving the experience for music, mixes, podcasts, and audiobooks. |
+| **[mpd-usb-automount](./mpd-usb-automount/)** | System-level (root) setup for a removable USB music disk: a stable udev device name, on-demand autofs mounting, and idle spindown. Has its own separate installer, not part of the top-level `install.sh`. |
 | **[mpd-smart-shuffle](./mpd-smart-shuffle/)** | A smarter shuffle: a background monitor records play/skip history, and a cron-run script tops up the MPD queue avoiding recent repeats, with optional weighted selection, artist/album diversity, seasonal and time-of-day genre filtering, exclude lists, and more. |
 | **[mpdsimilar](./mpdsimilar/)** | Fetches similar artist tracks from Last.fm for the currently playing track or every track in the queue, and adds a sample of them to the MPD queue. |
 | **[rm-duplicates-playlist](./rm-duplicates-playlist/)** | Removes duplicate entries from a saved MPD playlist or the current queue, or lists available playlists, combining what the two `mpd-find-dup` scripts each do separately into one tool. |
@@ -92,6 +93,7 @@ Contributions are welcome!
 - [mpd-kb-control](./mpd-kb-control/) is based on [mpd_kb_control](https://github.com/nogaems/mpd_kb_control) by nogaems.
 - [mpd-auto-stop](./mpd-auto-stop/) is based on [mpd_auto_stop](https://github.com/vms20591/mpd_auto_stop) by Meenakshi Sundaram V.
 - [add-current-song](./add-current-song/) and [mpd-random-album](./mpd-random-album/) are derived from [Alejandro-Roldan/mpc-scripts](https://github.com/Alejandro-Roldan/mpc-scripts).
+- [mpd-usb-automount](./mpd-usb-automount/) is based on a [gist](https://gist.github.com/daks/8030543) by [daks](https://gist.github.com/daks).
 - Documentation updates assisted by [Claude](https://www.anthropic.com/claude).
 
 ## License

--- a/mpd-usb-automount/10-mpd-disk.rules.example
+++ b/mpd-usb-automount/10-mpd-disk.rules.example
@@ -1,0 +1,11 @@
+# 10-mpd-disk.rules
+#
+# Installed to /etc/udev/rules.d/10-mpd-disk.rules by install.sh, which
+# substitutes in your actual disk's vendor/product/serial IDs (run
+# "install.sh --detect /dev/sdX1" to fill these in automatically instead
+# of hunting through `udevadm info` output by hand).
+#
+# Creates a stable /dev/mpd-disk symlink for your MPD music disk,
+# regardless of which /dev/sdX name the kernel happens to assign it on any
+# given boot, and runs hdparm-mpd-disk.sh whenever the device appears.
+KERNEL=="sd?1",ATTRS{idVendor}=="__ID_VENDOR__",ATTRS{idProduct}=="__ID_PRODUCT__",ATTRS{serial}=="__ID_SERIAL__",SYMLINK+="mpd-disk",RUN+="/usr/local/sbin/hdparm-mpd-disk.sh"

--- a/mpd-usb-automount/README.md
+++ b/mpd-usb-automount/README.md
@@ -1,0 +1,86 @@
+# mpd-usb-automount
+
+Keeps MPD's music library on a removable USB disk that's mounted only when actually needed -- a stable device name via `udev` (survives reboots/enumeration-order changes), on-demand mounting via `autofs`, and an idle spindown timer, so the disk isn't spinning 24/7 on a device like a Raspberry Pi.
+
+> **This installer is not wired into `mpd-scripts`' top-level `install.sh`.** It needs root, writes to `/etc` (udev rules, autofs config) rather than your home directory, and needs your specific disk's hardware IDs. Run it deliberately and separately: `cd mpd-usb-automount && sudo ./install.sh ...`.
+
+## How it works
+
+MPD's `music_directory` in `mpd.conf` stays pointed at the boring, always-present default (`/var/lib/mpd/music`) -- never at the removable disk directly. A **symlink** inside that directory (e.g. `Music` → `/media/mpd-auto/mpd-disk/Music`) is the only thing that points at the USB disk, and `follow_outside_symlinks`/`follow_inside_symlinks` are both set to `"yes"` specifically so MPD is willing to traverse it (MPD refuses to follow symlinks by default).
+
+Because `autofs` only mounts `/media/mpd-auto/mpd-disk` on first *access* rather than on existence check, MPD can start and browse its library structure without forcing the drive to spin up -- it only mounts, and the disk only spins up, the moment something actually reads through that symlink (an initial database scan, or later, playback). It unmounts again after 60 seconds idle.
+
+## Requirements
+
+- `udev` (standard on any Linux distro)
+- `autofs` (the installer offers to `apt install` it if missing)
+- `hdparm`
+- A USB disk you can identify by vendor/product/serial ID
+
+## Installation
+
+```bash
+cd mpd-usb-automount
+
+# Plug in the disk, then let install.sh find its vendor/product/serial
+# automatically:
+sudo ./install.sh --detect /dev/sdX1
+
+# ...or specify them directly if you already know them:
+sudo ./install.sh --vendor 0951 --product 1666 --serial 60A44C4B1234ABCD
+```
+
+This installs the udev rule, the autofs map and drop-in config, and the hdparm helper script, then reloads udev and restarts autofs. It also checks whether `/etc/mpd.conf` already has the required directives and tells you if not (it won't edit `mpd.conf` itself -- see [mpd.conf.snippet](./mpd.conf.snippet)).
+
+**Remaining manual steps** (the installer prints these at the end too):
+
+1. Confirm the disk shows up: `ls -l /dev/mpd-disk`
+2. Symlink MPD's music directory to the disk's actual music folder:
+   ```bash
+   cd /var/lib/mpd/music
+   sudo ln -s /media/mpd-auto/mpd-disk/Music Music
+   ```
+   (adjust `Music` to your disk's actual top-level folder name)
+3. Restart MPD and run an initial database update:
+   ```bash
+   sudo systemctl restart mpd
+   mpc update
+   ```
+
+## Files
+
+| File | Installed to |
+| --- | --- |
+| [`10-mpd-disk.rules.example`](./10-mpd-disk.rules.example) | `/etc/udev/rules.d/10-mpd-disk.rules` (with your disk's IDs substituted in) |
+| [`mpd-disk.autofs`](./mpd-disk.autofs) | `/etc/auto.master.d/mpd-disk.autofs` |
+| [`auto.mpd-disk`](./auto.mpd-disk) | `/etc/auto.mpd-disk` |
+| [`hdparm-mpd-disk.sh`](./hdparm-mpd-disk.sh) | `/usr/local/sbin/hdparm-mpd-disk.sh` |
+| [`mpd.conf.snippet`](./mpd.conf.snippet) | *(reference only -- add to `/etc/mpd.conf` by hand)* |
+
+## Uninstallation
+
+```bash
+sudo rm /etc/udev/rules.d/10-mpd-disk.rules
+sudo rm /etc/auto.master.d/mpd-disk.autofs
+sudo rm /etc/auto.mpd-disk
+sudo rm /usr/local/sbin/hdparm-mpd-disk.sh
+sudo udevadm control --reload-rules
+sudo systemctl restart autofs
+```
+Then remove the `follow_outside_symlinks`/`follow_inside_symlinks` lines from `/etc/mpd.conf` and the `Music` symlink under your `music_directory`, if you no longer want them.
+
+## Acknowledgments
+
+Based on a [gist by daks](https://gist.github.com/daks/8030543). Changes from the original:
+
+- The original's `hdparm-mpd-disk.sh` checked power status on a hardcoded `/dev/sda` while setting the spindown timer on the stable `/dev/mpd-disk` symlink -- inconsistent, and defeats the udev rule's entire purpose (a stable name specifically because raw `/dev/sdX` naming isn't reliable) for that one check. Both commands now consistently target `/dev/mpd-disk`.
+- Output is now logged via `logger` instead of silently discarded -- `udev RUN+=` scripts have no visible stdout/stderr otherwise, so a failure (missing `hdparm`, device gone) previously vanished without a trace.
+- `install.sh --detect DEVICE` reads `udevadm info --query=property`'s already-resolved `ID_VENDOR_ID`/`ID_MODEL_ID`/`ID_SERIAL_SHORT` properties directly, instead of requiring you to manually walk `udevadm info -a -p` parent-device output looking for a unique attribute combination.
+- The autofs map moved from a shared `/media/auto` + `auto.media` (which could collide with an unrelated existing autofs map on the same system) to a dedicated `/media/mpd-auto` + `auto.mpd-disk`, and uses the modern `/etc/auto.master.d/*.autofs` drop-in mechanism instead of requiring an edit to the shared `/etc/auto.master`.
+- `hdparm-mpd-disk.sh` installs to `/usr/local/sbin` (the conventional location for locally-added system scripts) rather than `/root/bin`.
+
+## License
+
+This project is licensed under the **GNU General Public License v3.0**.
+
+See [LICENSE](../LICENSE) for more information.

--- a/mpd-usb-automount/auto.mpd-disk
+++ b/mpd-usb-automount/auto.mpd-disk
@@ -1,0 +1,6 @@
+# auto.mpd-disk
+#
+# Installed to /etc/auto.mpd-disk by install.sh. Maps /dev/mpd-disk (the
+# stable symlink 10-mpd-disk.rules creates) to /media/mpd-auto/mpd-disk,
+# mounted on demand by autofs.
+mpd-disk	-fstype=auto	:/dev/mpd-disk

--- a/mpd-usb-automount/hdparm-mpd-disk.sh
+++ b/mpd-usb-automount/hdparm-mpd-disk.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/bash
+
+#
+# hdparm-mpd-disk.sh
+#
+# Installed to /usr/local/sbin/hdparm-mpd-disk.sh and run by udev
+# (10-mpd-disk.rules) whenever the MPD disk's stable /dev/mpd-disk symlink
+# appears.
+#
+# Always targets /dev/mpd-disk, the stable symlink the udev rule creates
+# -- never a raw /dev/sdX name. The whole point of that rule is that the
+# raw device name isn't reliable across boots or enumeration order, so
+# using it here would defeat it.
+#
+# Output goes to the system log via logger, since udev RUN+= scripts have
+# nowhere else visible to send stdout/stderr -- otherwise a failure here
+# (e.g. hdparm not installed, or the device gone by the time this runs)
+# would be silently swallowed.
+#
+
+DEVICE=/dev/mpd-disk
+
+# Report current power status (see the -C section of `man hdparm`).
+/sbin/hdparm -C "$DEVICE" 2>&1 | logger -t hdparm-mpd-disk
+
+# Set the idle spindown timer to 2 minutes. -S takes a value 1-240 meaning
+# multiples of 5 seconds (see the -S section of `man hdparm` for the full
+# encoding table); 24 * 5s = 120s.
+/sbin/hdparm -S 24 "$DEVICE" 2>&1 | logger -t hdparm-mpd-disk

--- a/mpd-usb-automount/install.sh
+++ b/mpd-usb-automount/install.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/bash
+
+#
+# mpd-usb-automount installer
+#
+# Sets up a removable USB disk as MPD's music library: a stable /dev
+# name via udev (survives reboots/enumeration-order changes), on-demand
+# mounting via autofs (the disk isn't spun up until something actually
+# reads from it), and an idle spindown timer.
+#
+# This installer is deliberately NOT wired into mpd-scripts' top-level
+# install.sh. It needs root, it writes to /etc (udev rules, autofs
+# config) rather than your home directory, and it needs your specific
+# disk's hardware IDs -- this should be a conscious, one-time, manual
+# step, not something a general "install everything" run does for you.
+#
+# See README.md before running this.
+#
+# Usage:
+#   sudo ./install.sh --detect /dev/sdX1
+#   sudo ./install.sh --vendor ID_VENDOR --product ID_PRODUCT --serial ID_SERIAL
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+UDEV_RULE_DEST=/etc/udev/rules.d/10-mpd-disk.rules
+AUTOFS_DROPIN_DEST=/etc/auto.master.d/mpd-disk.autofs
+AUTOFS_MAP_DEST=/etc/auto.mpd-disk
+HDPARM_SCRIPT_DEST=/usr/local/sbin/hdparm-mpd-disk.sh
+MPD_CONF=/etc/mpd.conf
+
+ID_VENDOR=""
+ID_PRODUCT=""
+ID_SERIAL=""
+DETECT_DEVICE=""
+
+usage() {
+    cat <<'EOF'
+Usage:
+  sudo ./install.sh --detect /dev/sdX1
+  sudo ./install.sh --vendor ID_VENDOR --product ID_PRODUCT --serial ID_SERIAL
+
+Options:
+  --detect DEVICE      Auto-detect idVendor/idProduct/serial from an
+                        already-plugged-in device (e.g. /dev/sda1) via
+                        udevadm, instead of specifying them manually.
+  --vendor ID_VENDOR    Set idVendor directly.
+  --product ID_PRODUCT  Set idProduct directly.
+  --serial ID_SERIAL    Set serial directly.
+  -h, --help            Show this help.
+
+Either --detect DEVICE, or all three of --vendor/--product/--serial, are
+required.
+EOF
+}
+
+#
+# Fills ID_VENDOR/ID_PRODUCT/ID_SERIAL from udevadm's already-resolved
+# properties for $1, instead of requiring you to manually walk
+# `udevadm info -a -p ...` parent-device output looking for a unique
+# combination.
+#
+detect_device_ids() {
+    local device="$1"
+    local props
+
+    if ! command -v udevadm >/dev/null 2>&1; then
+        echo "Error: udevadm not found." >&2
+        exit 1
+    fi
+
+    if [[ ! -e "$device" ]]; then
+        echo "Error: $device does not exist. Plug in the disk first." >&2
+        exit 1
+    fi
+
+    if ! props="$(udevadm info --query=property --name="$device" 2>/dev/null)"; then
+        echo "Error: udevadm could not query $device." >&2
+        exit 1
+    fi
+
+    ID_VENDOR="$(grep -m1 '^ID_VENDOR_ID=' <<< "$props" | cut -d= -f2-)"
+    ID_PRODUCT="$(grep -m1 '^ID_MODEL_ID=' <<< "$props" | cut -d= -f2-)"
+    ID_SERIAL="$(grep -m1 '^ID_SERIAL_SHORT=' <<< "$props" | cut -d= -f2-)"
+
+    if [[ -z "$ID_VENDOR" || -z "$ID_PRODUCT" || -z "$ID_SERIAL" ]]; then
+        echo "Error: could not determine idVendor/idProduct/serial for $device." >&2
+        echo "Raw udevadm properties for reference:" >&2
+        echo "$props" >&2
+        echo "You may need to set --vendor/--product/--serial manually instead." >&2
+        exit 1
+    fi
+
+    echo "Detected: idVendor=$ID_VENDOR idProduct=$ID_PRODUCT serial=$ID_SERIAL"
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --detect)
+            DETECT_DEVICE="${2:?--detect requires a device path}"
+            shift 2
+            ;;
+        --vendor)
+            ID_VENDOR="${2:?--vendor requires a value}"
+            shift 2
+            ;;
+        --product)
+            ID_PRODUCT="${2:?--product requires a value}"
+            shift 2
+            ;;
+        --serial)
+            ID_SERIAL="${2:?--serial requires a value}"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -n "$DETECT_DEVICE" ]]; then
+    detect_device_ids "$DETECT_DEVICE"
+fi
+
+if [[ -z "$ID_VENDOR" || -z "$ID_PRODUCT" || -z "$ID_SERIAL" ]]; then
+    echo "Error: idVendor/idProduct/serial not set." >&2
+    usage >&2
+    exit 1
+fi
+
+if [[ "$(id -u)" -ne 0 ]]; then
+    echo "Error: this installer must be run as root (it writes to /etc and /usr/local/sbin)." >&2
+    echo "Try: sudo $0 [options]" >&2
+    exit 1
+fi
+
+echo "Installing udev rule to $UDEV_RULE_DEST..."
+sed \
+    -e "s/__ID_VENDOR__/$ID_VENDOR/" \
+    -e "s/__ID_PRODUCT__/$ID_PRODUCT/" \
+    -e "s/__ID_SERIAL__/$ID_SERIAL/" \
+    "$SCRIPT_DIR/10-mpd-disk.rules.example" > "$UDEV_RULE_DEST"
+chmod 644 "$UDEV_RULE_DEST"
+
+echo "Installing hdparm script to $HDPARM_SCRIPT_DEST..."
+cp "$SCRIPT_DIR/hdparm-mpd-disk.sh" "$HDPARM_SCRIPT_DEST"
+chmod 755 "$HDPARM_SCRIPT_DEST"
+
+echo "Reloading udev rules..."
+udevadm control --reload-rules
+udevadm trigger
+
+if ! dpkg -s autofs >/dev/null 2>&1; then
+    echo "autofs does not appear to be installed."
+    read -r -p "Install it now via apt? [Y/n] " REPLY
+    if [[ ! "$REPLY" =~ ^[Nn]$ ]]; then
+        apt-get update
+        apt-get install -y autofs
+    else
+        echo "Skipped. Install it manually before continuing: sudo apt-get install autofs"
+    fi
+fi
+
+echo "Installing autofs map to $AUTOFS_MAP_DEST..."
+cp "$SCRIPT_DIR/auto.mpd-disk" "$AUTOFS_MAP_DEST"
+chmod 644 "$AUTOFS_MAP_DEST"
+
+echo "Installing autofs drop-in to $AUTOFS_DROPIN_DEST..."
+mkdir -p /etc/auto.master.d
+cp "$SCRIPT_DIR/mpd-disk.autofs" "$AUTOFS_DROPIN_DEST"
+chmod 644 "$AUTOFS_DROPIN_DEST"
+
+if command -v systemctl >/dev/null 2>&1; then
+    echo "Restarting autofs..."
+    systemctl restart autofs
+    systemctl enable autofs >/dev/null 2>&1 || true
+else
+    echo "systemctl not found; restart the autofs service manually, e.g.: service autofs restart"
+fi
+
+echo
+echo "Checking $MPD_CONF for the required directives..."
+if [[ -f "$MPD_CONF" ]]; then
+    missing=()
+    grep -Eq '^[[:space:]]*follow_outside_symlinks[[:space:]]+"yes"' "$MPD_CONF" ||
+        missing+=('follow_outside_symlinks "yes"')
+    grep -Eq '^[[:space:]]*follow_inside_symlinks[[:space:]]+"yes"' "$MPD_CONF" ||
+        missing+=('follow_inside_symlinks "yes"')
+
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        echo "The following directives are missing from $MPD_CONF and must be added manually:"
+        for line in "${missing[@]}"; do
+            echo "  $line"
+        done
+        echo "See mpd.conf.snippet in this directory for the full reference."
+    else
+        echo "Required mpd.conf directives are already present."
+    fi
+else
+    echo "Warning: $MPD_CONF not found; add the directives from mpd.conf.snippet once MPD is installed."
+fi
+
+echo
+echo "Installation complete. Remaining manual steps:"
+echo "  1. Plug in the disk (if not already) and confirm it appears at /dev/mpd-disk:"
+echo "       ls -l /dev/mpd-disk"
+echo "  2. Symlink MPD's music_directory to the disk's actual music folder, e.g.:"
+echo "       cd /var/lib/mpd/music && sudo ln -s /media/mpd-auto/mpd-disk/Music Music"
+echo "     (adjust \"Music\" to match your disk's actual top-level folder name)"
+echo "  3. Restart MPD and run an initial database update:"
+echo "       sudo systemctl restart mpd"
+echo "       mpc update"

--- a/mpd-usb-automount/mpd-disk.autofs
+++ b/mpd-usb-automount/mpd-disk.autofs
@@ -1,0 +1,9 @@
+# mpd-disk.autofs
+#
+# Installed to /etc/auto.master.d/mpd-disk.autofs by install.sh.
+#
+# A dedicated /media/mpd-auto mount root (rather than reusing a generic
+# /media/auto) avoids colliding with any other autofs map you might
+# already have. --timeout=60 unmounts the disk again after 60 seconds of
+# no access, so it isn't spun up 24/7.
+/media/mpd-auto	/etc/auto.mpd-disk	--timeout=60

--- a/mpd-usb-automount/mpd.conf.snippet
+++ b/mpd-usb-automount/mpd.conf.snippet
@@ -1,0 +1,15 @@
+# mpd.conf.snippet
+#
+# Add these directives to your /etc/mpd.conf (install.sh checks whether
+# they're already present but does not edit mpd.conf automatically --
+# patching a config file you've likely already customized is riskier than
+# a clear manual step).
+#
+# Leave music_directory pointing at wherever it already does (the default
+# is /var/lib/mpd/music) even though your real music lives on the
+# removable disk -- see this project's README.md for why that matters.
+# Only the two directives below need adding.
+
+follow_outside_symlinks	"yes"
+
+follow_inside_symlinks		"yes"


### PR DESCRIPTION
## Summary

Adds a system-level (root) setup for keeping MPD's library on a removable USB disk: a stable `/dev` name via udev, on-demand mounting via autofs, and idle spindown -- based on a [gist by daks](https://gist.github.com/daks/8030543).

**Bug fixed from the original:** the `hdparm` helper checked power status on a hardcoded `/dev/sda` while setting the spindown timer on the stable `/dev/mpd-disk` symlink -- inconsistent, and defeats the udev rule's entire purpose (a stable name specifically because raw `/dev/sdX` naming isn't reliable) for that one check. Both commands now consistently target `/dev/mpd-disk`. Output also now goes through `logger` instead of vanishing (`udev RUN+=` scripts have no visible stdout/stderr otherwise).

**Implementation improvements:**
- `install.sh --detect DEVICE` reads udevadm's already-resolved `ID_VENDOR_ID`/`ID_MODEL_ID`/`ID_SERIAL_SHORT` properties directly, instead of requiring manual `udevadm info -a -p` parent-device spelunking
- Checks `/etc/mpd.conf` for the required directives and reports what's missing, without blindly patching a config you've likely customized
- Dedicated `/media/mpd-auto` + the modern `/etc/auto.master.d/*.autofs` drop-in, instead of a shared `/media/auto` + editing the monolithic `/etc/auto.master`
- Installed helper script goes to `/usr/local/sbin` (conventional) instead of `/root/bin`

**Deliberately NOT wired into the top-level `install.sh`** -- it needs root, writes to `/etc`, and needs per-disk hardware IDs, so it should stay a conscious, separate, manual step. Registered in the top-level README for discoverability only; `install.sh` itself has zero diff.

## Test plan
- [x] `shellcheck` clean on both scripts
- [x] `--help`, no-args, and not-root paths all fail cleanly with proper messages (verified, since real root/hardware isn't available to test the actual install)
- [x] Auto-detection verified against a mocked `udevadm` returning realistic device properties -- correctly extracted vendor/product/serial
- [x] udev rule template substitution verified to produce a correctly-formed rule (caught and fixed a cosmetic bug of my own along the way -- the placeholder tokens appeared in the template's explanatory comment too, so substitution mangled the comment text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)