### PR TITLE
mpd-recent-tracks: add -P/--presets for named time-window playlists

### DIFF
--- a/mpd-recent-tracks/README.md
+++ b/mpd-recent-tracks/README.md
@@ -14,6 +14,7 @@ This script **automatically generates a playlist** of songs **added or modified 
 - **Configurable audio formats**: `EXTENSIONS` in the config controls which file extensions are scanned (default: `mp3 m4a flac ogg`).
 - **Exclude patterns**: `exclude_paths.txt` lists glob patterns (relative to `MUSIC_DIR`) to skip, e.g. an entire `Podcasts/` folder.
 - **Removes empty playlists**: If no new songs are found, the existing playlist is deleted. A failed run (e.g. a permission error) never touches an existing playlist — the new one is only swapped in once generation succeeds.
+- **Named time-window presets**: `-P/--presets` generates one playlist per `PRESETS` entry in the config (e.g. a week/month/year set) in a single run, instead of one playlist per invocation.
 
 ## Requirements
 - **MPD (Music Player Daemon)**
@@ -36,12 +37,30 @@ template, then run the script again.
 | `DEFAULT_DAYS_OLD` | Default number of days if `-d/--days` isn't given             | `30`                       |
 | `EXTENSIONS`       | Space-separated file extensions (no leading dot) to scan for  | `mp3 m4a flac ogg`         |
 | `EXCLUDE_FILE`     | Exclude-patterns filename, resolved relative to the config dir| `exclude_paths.txt`        |
+| `PRESETS`          | Array of `"NAME:DAYS"` entries used by `-P/--presets`         | see below                  |
 
 ### Playlist Location
-- The generated playlist will be located at:
+- The single-playlist mode (no `-P`) writes to:
   ```
   [PLAYLIST_DIR]/[PLAYLIST_TITLE].m3u
   ```
+- Each `-P/--presets` entry writes its own file instead:
+  ```
+  [PLAYLIST_DIR]/[NAME].m3u
+  ```
+
+### Presets
+`PRESETS` is a bash array of `"NAME:DAYS"` strings, one per named playlist `-P/--presets` should generate:
+
+```bash
+PRESETS=(
+    "New_Last_Week:7"
+    "New_Last_Month:31"
+    "New_Last_Year:365"
+)
+```
+
+`NAME` becomes that entry's playlist title (avoid spaces in it -- use underscores, since it's split from `DAYS` on the first `:`); `DAYS` is that entry's own day count, independent of `DEFAULT_DAYS_OLD`. `-n/--limit`/`-r/--random` still apply, capping or sampling each generated playlist the same way they would in single-playlist mode. `-d/--days` and `-l/--load` can't be combined with `-P` -- day count comes from each preset individually, and there's no single resulting playlist for `-l/--load` to load.
 
 ### Excluding paths
 `exclude_paths.txt` (seeded from `exclude_paths.txt.example` into the same
@@ -62,14 +81,16 @@ no active patterns to disable exclusion entirely.
 ### Running the script:
 ```bash
 ./mpd-recent-tracks.sh [-d <days>] [-n <limit> | -r <count>] [-q] [-l [-p]]
+./mpd-recent-tracks.sh -P [-n <limit> | -r <count>] [-q]
 ```
 
 ### Available Options
-- **-d, --days N**: Number of days to look back for recently added/modified files. If not given, uses `DEFAULT_DAYS_OLD` from the config.
-- **-n, --limit N**: Cap the playlist at N songs (newest first).
+- **-d, --days N**: Number of days to look back for recently added/modified files. If not given, uses `DEFAULT_DAYS_OLD` from the config. Errors if combined with `-P/--presets`.
+- **-n, --limit N**: Cap the playlist at N songs (newest first). With `-P/--presets`, applies to each generated playlist.
 - **-r, --random N**: Pick N songs at random from the recent-tracks pool, instead of the newest N. Requires `shuf`. Errors if combined with `-n/--limit`.
+- **-P, --presets**: Generate one playlist per `PRESETS` entry from the config instead of a single playlist. Errors if combined with `-d/--days` or `-l/--load`.
 - **-q, --quiet**: Suppress informational output; only errors are printed.
-- **-l, --load**: Load the generated playlist into MPD via `mpc load` after creating it. Requires `mpc`. Playback is left paused unless `-p/--play` is also given.
+- **-l, --load**: Load the generated playlist into MPD via `mpc load` after creating it. Requires `mpc`. Playback is left paused unless `-p/--play` is also given. Errors if combined with `-P/--presets`.
 - **-p, --play**: With `-l/--load`, also start playback via `mpc play` after loading. Errors if given without `-l/--load`.
 - **-h, --help**: Show usage and exit.
 
@@ -97,6 +118,14 @@ no active patterns to disable exclusion entirely.
 - **Generate, load, and start playing immediately**:
   ```bash
   ./mpd-recent-tracks.sh -l -p
+  ```
+- **Generate the week/month/year preset playlists in one run**:
+  ```bash
+  ./mpd-recent-tracks.sh -P
+  ```
+- **Same, capped at 50 songs each**:
+  ```bash
+  ./mpd-recent-tracks.sh -P -n 50
   ```
 
 ## Error Handling

--- a/mpd-recent-tracks/mpd-recent-tracks.conf.example
+++ b/mpd-recent-tracks/mpd-recent-tracks.conf.example
@@ -27,3 +27,14 @@ EXTENSIONS="mp3 m4a flac ogg"
 # exclude_paths.txt.example on first run. Leave every line commented out
 # (or the file empty) to disable exclusion.
 EXCLUDE_FILE="exclude_paths.txt"
+
+# Named time-window presets used by -P/--presets: one "NAME:DAYS" string
+# per array element. NAME becomes that playlist's title (avoid spaces --
+# use underscores instead, since NAME is split on the first ":" alone).
+# DAYS is how many days back to look for that entry. Each preset produces
+# its own "$PLAYLIST_DIR/NAME.m3u", independent of PLAYLIST_TITLE above.
+PRESETS=(
+    "New_Last_Week:7"
+    "New_Last_Month:31"
+    "New_Last_Year:365"
+)

--- a/mpd-recent-tracks/mpd-recent-tracks.sh
+++ b/mpd-recent-tracks/mpd-recent-tracks.sh
@@ -4,9 +4,13 @@
 #              or modified in the last N days, with paths relative to
 #              MUSIC_DIR so MPD can resolve them.
 # Usage: ./mpd-recent-tracks.sh [-d <days>] [-n <limit> | -r <count>] [-q] [-l [-p]]
+#        ./mpd-recent-tracks.sh -P [-n <limit> | -r <count>] [-q]
 #   -d, --days    Number of days to look back (default: DEFAULT_DAYS_OLD from config)
 #   -n, --limit   Cap the playlist at this many songs (newest first)
 #   -r, --random  Pick this many songs at random from the recent-tracks pool
+#   -P, --presets Generate one playlist per PRESETS entry from the config,
+#                 instead of a single playlist. Cannot be combined with
+#                 -d/--days or -l/--load (there's no single playlist to load).
 #   -q, --quiet   Suppress informational output; only errors are printed
 #   -l, --load    Load the generated playlist into MPD via `mpc load` (left paused)
 #   -p, --play    With -l/--load, also start playback via `mpc play`
@@ -14,17 +18,19 @@
 #
 # Configuration:
 #   PLAYLIST_DIR, MUSIC_DIR, PLAYLIST_TITLE, DEFAULT_DAYS_OLD, EXTENSIONS,
-#   and EXCLUDE_FILE live in
+#   EXCLUDE_FILE, and PRESETS live in
 #   ~/.config/mpd-scripts/mpd-recent-tracks/mpd-recent-tracks.conf, seeded
 #   from mpd-recent-tracks.conf.example (shipped alongside this script) on
 #   first run. EXCLUDE_FILE (default exclude_paths.txt, seeded from
-#   exclude_paths.txt.example) lists glob patterns to skip.
+#   exclude_paths.txt.example) lists glob patterns to skip. PRESETS is an
+#   array of "NAME:DAYS" entries used by -P/--presets.
 
 set -euo pipefail
 
 DAYS_OLD=""
 LIMIT=""
 RANDOM_COUNT=""
+PRESETS_MODE=false
 QUIET=false
 LOAD=false
 PLAY=false
@@ -39,6 +45,7 @@ usage() {
 display_help() {
     cat <<HELP
 Usage: $(basename "$0") [-d <days>] [-n <limit> | -r <count>] [-q] [-l [-p]]
+       $(basename "$0") -P [-n <limit> | -r <count>] [-q]
 
 Generates an M3U playlist (newest first) of music files added or modified
 in the last <days> days (default: DEFAULT_DAYS_OLD from config).
@@ -48,6 +55,11 @@ Options:
   -n, --limit N   Cap the playlist at this many songs (newest first).
   -r, --random N  Pick N songs at random from the recent-tracks pool,
                   instead of the newest N. Cannot be combined with -n/--limit.
+  -P, --presets   Generate one playlist per PRESETS entry from the config
+                  (each with its own name and day count) instead of a
+                  single playlist. -n/--limit and -r/--random still apply
+                  to each one. Cannot be combined with -d/--days or
+                  -l/--load.
   -q, --quiet     Suppress informational output; only errors are printed.
   -l, --load      Load the generated playlist into MPD via 'mpc load'.
                   Playback is left paused unless -p/--play is also given.
@@ -81,6 +93,7 @@ while [[ $# -gt 0 ]]; do
             RANDOM_COUNT="$2"
             shift 2
             ;;
+        -P|--presets) PRESETS_MODE=true; shift ;;
         -q|--quiet) QUIET=true; shift ;;
         -l|--load) LOAD=true; shift ;;
         -p|--play) PLAY=true; shift ;;
@@ -109,6 +122,14 @@ if [[ -n "$RANDOM_COUNT" ]] && ! command -v shuf &> /dev/null; then
     exit 1
 fi
 
+if [[ "$PRESETS_MODE" == true && -n "$DAYS_OLD" ]]; then
+    usage "Error: -P/--presets and -d/--days cannot be used together (each preset sets its own day count)."
+fi
+
+if [[ "$PRESETS_MODE" == true && "$LOAD" == true ]]; then
+    usage "Error: -P/--presets and -l/--load cannot be used together (there's no single playlist to load)."
+fi
+
 if [[ "$PLAY" == true && "$LOAD" == false ]]; then
     usage "Error: -p/--play requires -l/--load."
 fi
@@ -134,6 +155,11 @@ if [[ ! -f "$CONFIG_FILE" ]]; then
     exit 1
 fi
 
+# Defaults to an empty array so -P/--presets fails with a clean error
+# message (see below) rather than set -u's raw "unbound variable" if an
+# existing config predates PRESETS and never defines it.
+PRESETS=()
+
 # shellcheck source=mpd-recent-tracks.conf.example
 source "$CONFIG_FILE"
 
@@ -144,6 +170,11 @@ fi
 
 if [[ -z "${EXTENSIONS// }" ]]; then
     echo "Error: $CONFIG_FILE has an empty EXTENSIONS list." >&2
+    exit 1
+fi
+
+if [[ "$PRESETS_MODE" == true && ${#PRESETS[@]} -eq 0 ]]; then
+    echo "Error: -P/--presets was given but PRESETS in $CONFIG_FILE is empty." >&2
     exit 1
 fi
 
@@ -159,11 +190,14 @@ while IFS= read -r line; do
     EXCLUDE_PATTERNS+=("$line")
 done < "$EXCLUDE_PATH"
 
-# Fall back to the configured default if -d/--days wasn't given
-DAYS_OLD="${DAYS_OLD:-$DEFAULT_DAYS_OLD}"
-if ! [[ "$DAYS_OLD" =~ ^[0-9]+$ ]]; then
-    usage "Error: -d/--days must be a non-negative integer, got '$DAYS_OLD'."
-fi
+# Build the `-iname "*.ext" -o -iname "*.ext" ...` clause from EXTENSIONS
+# so the matched formats are configurable instead of hardcoded.
+read -ra EXT_LIST <<< "$EXTENSIONS"
+FIND_NAME_ARGS=()
+for ext in "${EXT_LIST[@]}"; do
+    [[ ${#FIND_NAME_ARGS[@]} -gt 0 ]] && FIND_NAME_ARGS+=(-o)
+    FIND_NAME_ARGS+=(-iname "*.${ext}")
+done
 
 if [[ ! -d "$PLAYLIST_DIR" ]]; then
     echo "Error: Playlist directory $PLAYLIST_DIR does not exist." >&2
@@ -175,80 +209,132 @@ if [[ ! -d "$MUSIC_DIR" ]]; then
     exit 1
 fi
 
-PLAYLIST_FILE="$PLAYLIST_DIR/${PLAYLIST_TITLE}.m3u"
-# Write to temp files first so a failed/interrupted run never touches an
-# existing good playlist; only replace it once we know the run succeeded.
-# SIZE_TMP holds the -n/--limit or -r/--random result before it replaces
-# TMP_FILE's full candidate list.
-TMP_FILE="$(mktemp "${PLAYLIST_FILE}.XXXXXX")"
-SIZE_TMP="$(mktemp "${PLAYLIST_FILE}.XXXXXX")"
+# TMP_FILE/SIZE_TMP are (re)created fresh by generate_playlist on each call
+# (once for the single-playlist path, once per PRESETS entry in -P mode).
+# Kept as plain globals, not function-local, so the single EXIT trap below
+# always cleans up whichever pair is currently in flight, including if the
+# script is interrupted mid-preset.
+TMP_FILE=""
+SIZE_TMP=""
 trap 'rm -f "$TMP_FILE" "$SIZE_TMP"' EXIT
 
-# Build the `-iname "*.ext" -o -iname "*.ext" ...` clause from EXTENSIONS
-# so the matched formats are configurable instead of hardcoded.
-read -ra EXT_LIST <<< "$EXTENSIONS"
-FIND_NAME_ARGS=()
-for ext in "${EXT_LIST[@]}"; do
-    [[ ${#FIND_NAME_ARGS[@]} -gt 0 ]] && FIND_NAME_ARGS+=(-o)
-    FIND_NAME_ARGS+=(-iname "*.${ext}")
-done
+# Generates one playlist named "$1" covering the last "$2" days, applying
+# the shared EXTENSIONS/EXCLUDE_PATTERNS/LIMIT/RANDOM_COUNT settings.
+# Called once for the default single-playlist path, or once per PRESETS
+# entry under -P/--presets.
+generate_playlist() {
+    local title="$1"
+    local days="$2"
+    local playlist_file total_files
 
-# Strip the MUSIC_DIR prefix (and any leading slash) from each match so
-# paths in the playlist are relative to MPD's music_directory. Using bash
-# parameter expansion (quoted, so it's a literal prefix match rather than a
-# glob/regex) avoids having to escape MUSIC_DIR against regex metacharacters
-# like "." or "(" that commonly show up in real directory names.
-#
-# `-printf '%T@ %p\0'` prefixes each match with its mtime (epoch seconds) so
-# `sort -z -rn -k1,1` can order the NUL-delimited records newest first
-# without breaking on paths that contain spaces or newlines. TMP_FILE gets
-# every matching candidate; -n/--limit or -r/--random is applied afterwards
-# as a separate pass over the full list (see below).
-if ! find -L "$MUSIC_DIR" -type f -mtime "-${DAYS_OLD}" \( "${FIND_NAME_ARGS[@]}" \) -printf '%T@ %p\0' |
-    sort -z -rn -k1,1 |
-    while IFS=' ' read -r -d '' _mtime file; do
-        relative="${file#"$MUSIC_DIR"}"
-        relative="${relative#/}"
+    if ! [[ "$days" =~ ^[0-9]+$ ]]; then
+        echo "Error: preset '$title' has an invalid day count: '$days'." >&2
+        exit 1
+    fi
 
-        excluded=false
-        for pattern in "${EXCLUDE_PATTERNS[@]}"; do
-            if [[ "$relative" == $pattern ]]; then
-                excluded=true
-                break
-            fi
-        done
-        [[ "$excluded" == true ]] && continue
+    playlist_file="$PLAYLIST_DIR/${title}.m3u"
+    # Write to temp files first so a failed/interrupted run never touches an
+    # existing good playlist; only replace it once we know the run succeeded.
+    # SIZE_TMP holds the -n/--limit or -r/--random result before it replaces
+    # TMP_FILE's full candidate list.
+    TMP_FILE="$(mktemp "${playlist_file}.XXXXXX")"
+    SIZE_TMP="$(mktemp "${playlist_file}.XXXXXX")"
 
-        printf '%s\n' "$relative"
-    done > "$TMP_FILE"; then
-    echo "Error: Failed to create playlist. Possible permission issue." >&2
-    exit 1
-fi
+    # Strip the MUSIC_DIR prefix (and any leading slash) from each match so
+    # paths in the playlist are relative to MPD's music_directory. Using bash
+    # parameter expansion (quoted, so it's a literal prefix match rather than
+    # a glob/regex) avoids having to escape MUSIC_DIR against regex
+    # metacharacters like "." or "(" that commonly show up in real directory
+    # names.
+    #
+    # `-printf '%T@ %p\0'` prefixes each match with its mtime (epoch seconds)
+    # so `sort -z -rn -k1,1` can order the NUL-delimited records newest first
+    # without breaking on paths that contain spaces or newlines. TMP_FILE
+    # gets every matching candidate; -n/--limit or -r/--random is applied
+    # afterwards as a separate pass over the full list (see below).
+    if ! find -L "$MUSIC_DIR" -type f -mtime "-${days}" \( "${FIND_NAME_ARGS[@]}" \) -printf '%T@ %p\0' |
+        sort -z -rn -k1,1 |
+        while IFS=' ' read -r -d '' _mtime file; do
+            relative="${file#"$MUSIC_DIR"}"
+            relative="${relative#/}"
 
-# Apply -r/--random (a random sample of the pool) or -n/--limit (the
-# newest N, which TMP_FILE is already sorted as) against the full
-# candidate list gathered above.
-if [[ -n "$RANDOM_COUNT" ]]; then
-    shuf -n "$RANDOM_COUNT" "$TMP_FILE" > "$SIZE_TMP"
-    mv "$SIZE_TMP" "$TMP_FILE"
-elif [[ -n "$LIMIT" ]]; then
-    head -n "$LIMIT" "$TMP_FILE" > "$SIZE_TMP"
-    mv "$SIZE_TMP" "$TMP_FILE"
-fi
+            excluded=false
+            for pattern in "${EXCLUDE_PATTERNS[@]}"; do
+                # $pattern is deliberately unquoted -- EXCLUDE_PATTERNS
+                # entries are glob patterns, and quoting would make this a
+                # literal-string comparison instead.
+                # shellcheck disable=SC2053
+                if [[ "$relative" == $pattern ]]; then
+                    excluded=true
+                    break
+                fi
+            done
+            [[ "$excluded" == true ]] && continue
 
-# Handle empty results: leave the temp file behind for the trap to clean up,
-# and only remove any existing playlist once we know this run genuinely
-# found nothing (as opposed to having failed, which is caught above).
-if [[ ! -s "$TMP_FILE" ]]; then
-    [[ "$QUIET" == true ]] || echo "Warning: No recent files found. Playlist is empty."
-    rm -f "$PLAYLIST_FILE"
+            printf '%s\n' "$relative"
+        done > "$TMP_FILE"; then
+        echo "Error: Failed to create playlist '$title'. Possible permission issue." >&2
+        exit 1
+    fi
+
+    # Apply -r/--random (a random sample of the pool) or -n/--limit (the
+    # newest N, which TMP_FILE is already sorted as) against the full
+    # candidate list gathered above.
+    if [[ -n "$RANDOM_COUNT" ]]; then
+        shuf -n "$RANDOM_COUNT" "$TMP_FILE" > "$SIZE_TMP"
+        mv "$SIZE_TMP" "$TMP_FILE"
+    elif [[ -n "$LIMIT" ]]; then
+        head -n "$LIMIT" "$TMP_FILE" > "$SIZE_TMP"
+        mv "$SIZE_TMP" "$TMP_FILE"
+    fi
+
+    # SIZE_TMP is only consumed (via the mv above) when -n/--limit or
+    # -r/--random is given; otherwise it's an unused empty temp file. The
+    # outer EXIT trap only catches whichever SIZE_TMP is current when the
+    # whole script finally exits, which under -P/--presets (multiple calls
+    # to this function) would otherwise leak one orphaned file per preset
+    # except the last. Removing it here explicitly, every call, closes that
+    # gap; harmless no-op if it was already moved away above.
+    rm -f "$SIZE_TMP"
+
+    # Handle empty results: leave the temp file behind for the trap to clean
+    # up, and only remove any existing playlist once we know this run
+    # genuinely found nothing (as opposed to having failed, which is caught
+    # above).
+    if [[ ! -s "$TMP_FILE" ]]; then
+        [[ "$QUIET" == true ]] || echo "Warning: No recent files found for '$title'. Playlist is empty."
+        rm -f "$playlist_file"
+        return 0
+    fi
+
+    mv "$TMP_FILE" "$playlist_file"
+
+    total_files=$(wc -l < "$playlist_file")
+    [[ "$QUIET" == true ]] || echo "Created the '$title' playlist with $total_files songs at $playlist_file."
+}
+
+if [[ "$PRESETS_MODE" == true ]]; then
+    for preset in "${PRESETS[@]}"; do
+        preset_name="${preset%%:*}"
+        preset_days="${preset#*:}"
+
+        if [[ -z "$preset_name" || "$preset_name" == "$preset" ]]; then
+            echo "Error: malformed PRESETS entry (expected NAME:DAYS): '$preset'." >&2
+            exit 1
+        fi
+
+        generate_playlist "$preset_name" "$preset_days"
+    done
     exit 0
 fi
 
-mv "$TMP_FILE" "$PLAYLIST_FILE"
+# Fall back to the configured default if -d/--days wasn't given
+DAYS_OLD="${DAYS_OLD:-$DEFAULT_DAYS_OLD}"
+if ! [[ "$DAYS_OLD" =~ ^[0-9]+$ ]]; then
+    usage "Error: -d/--days must be a non-negative integer, got '$DAYS_OLD'."
+fi
 
-TOTAL_FILES=$(wc -l < "$PLAYLIST_FILE")
-[[ "$QUIET" == true ]] || echo "Created the '$PLAYLIST_TITLE' playlist with $TOTAL_FILES songs at $PLAYLIST_FILE."
+generate_playlist "$PLAYLIST_TITLE" "$DAYS_OLD"
 
 if [[ "$LOAD" == true ]]; then
     # `mpc load` only queues the songs; it never starts playback on its own,


### PR DESCRIPTION
## Summary

Adds `-P/--presets` to `mpd-recent-tracks`: generate one playlist per named time-window entry (a `"NAME:DAYS"` config array) in a single run, instead of one playlist per invocation. Shipped default matches a week/month/year split (`New_Last_Week:7`, `New_Last_Month:31`, `New_Last_Year:365`).

- `-d/--days` and `-l/--load` are rejected together with `-P` -- day count comes from each preset individually, and there's no single resulting playlist for `-l/--load` to load
- `-n/--limit`/`-r/--random` still apply, to each generated playlist
- Refactored the core find/sort/filter/write logic into a shared `generate_playlist` function, used by both the existing single-playlist path (unchanged behavior) and the new per-preset loop

**Two bugs caught and fixed during my own testing, not just the happy path:**
- Looping the extracted function leaked an orphaned temp file per preset (except the last) -- the original single-call design relied on a single `EXIT` trap, which isn't enough once the same temp-file variables get reused across multiple loop iterations
- Running `-P` against an existing config from before this feature (no `PRESETS` line at all) crashed with a raw `unbound variable` under `set -u` instead of a clean error message

## Test plan
- [x] `shellcheck` clean (also fixed a pre-existing, harmless `SC2053` warning with a documented disable while in there)
- [x] Regression-tested the existing single-playlist path unchanged: `-d`, `-n`, `-r`, `-l`/`-p`, first-run config seeding
- [x] `-P` producing correct, independently-sized playlists per window (verified against fixtures with distinct mtimes)
- [x] `-P -n` applying the limit to each generated playlist
- [x] `-P`+`-d` and `-P`+`-l` both rejected with clear errors
- [x] A malformed `NAME:DAYS` preset entry rejected cleanly
- [x] Both bugs above reproduced, fixed, and reverified
- [x] A freshly-seeded config (never run before) working with `-P` out of the box

🤖 Generated with [Claude Code](https://claude.com/claude-code)