### PR TITLE
mpd-random-album: add recent-albums cache and -y/--year filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Collection of scripts related to mpd & mpc.
 | **[rm-artists-playlist](./rm-artists-playlist/)** | Removes songs by a list of artists from a saved MPD playlist or the current queue, or lists available playlists. |
 | **[mpd-add-random-artist](./mpd-add-random-artist/)** | Adds a random sample of a specified artist's tracks to the current MPD queue, matching exactly by default or loosely with `-l`. |
 | **[mpd-add-random](./mpd-add-random/)** | Adds a random selection of tracks from the local music library to the current MPD queue. |
-| **[mpd-random-album](./mpd-random-album/)** | Clears the queue and replaces it with randomly selected complete albums, saving and restoring the original queue/state if anything fails. |
+| **[mpd-random-album](./mpd-random-album/)** | Clears the queue and replaces it with randomly selected complete albums, with an optional year filter, a recent-picks cache to avoid repeats, saving and restoring the original queue/state if anything fails. |
 | **[add-current-song](./add-current-song/)** | Adds the currently playing MPD song to an M3U playlist, with duplicate prevention, sorting, locking, and atomic rewrites. |
 | **[mpd-tray-icon](./mpd-tray-icon/)** | A GTK3 tray icon showing the currently playing MPD track, with Play/Pause/Next/Previous controls. |
 | **[mpd-radio-tray](./mpd-radio-tray/)** | A PyQt5 system tray app for managing and playing categorized internet radio station URLs with MPD, similar to RadioTray-NG. |
@@ -92,7 +92,7 @@ Contributions are welcome!
 - [alarmpd](./alarmpd/) is based on [alarmpd](https://github.com/ingobecker/alarmpd) by Ingo Becker.
 - [mpd-kb-control](./mpd-kb-control/) is based on [mpd_kb_control](https://github.com/nogaems/mpd_kb_control) by nogaems.
 - [mpd-auto-stop](./mpd-auto-stop/) is based on [mpd_auto_stop](https://github.com/vms20591/mpd_auto_stop) by Meenakshi Sundaram V.
-- [add-current-song](./add-current-song/) and [mpd-random-album](./mpd-random-album/) are derived from [Alejandro-Roldan/mpc-scripts](https://github.com/Alejandro-Roldan/mpc-scripts).
+- [add-current-song](./add-current-song/) and [mpd-random-album](./mpd-random-album/) are derived from [Alejandro-Roldan/mpc-scripts](https://github.com/Alejandro-Roldan/mpc-scripts); [mpd-random-album](./mpd-random-album/)'s recent-albums cache was additionally inspired by [ibeex/mpd_queue_random_album](https://github.com/ibeex/mpd_queue_random_album).
 - [mpd-usb-automount](./mpd-usb-automount/) is based on a [gist](https://gist.github.com/daks/8030543) by [daks](https://gist.github.com/daks).
 - Documentation updates assisted by [Claude](https://www.anthropic.com/claude).
 

--- a/mpd-random-album/README.md
+++ b/mpd-random-album/README.md
@@ -4,7 +4,9 @@ Clears the current MPD queue and replaces it with a randomly selected collection
 
 ## Features
 
-- Selects random unique album/album-artist combinations, using exact matching (`mpc find`, not `mpc search`) so similarly-named albums (e.g. `The Wall` vs. `The Wall (Remastered)`) don't get conflated
+- Selects random unique album/album-artist combinations, using exact matching (`mpc find`, not `mpc search`) so similarly-named albums (e.g. `The Wall` vs. `The Wall (Remastered)`) don't get conflated -- including two *different artists'* albums that happen to share a title (e.g. two unrelated "Greatest Hits"), which are kept fully separate rather than treated as duplicates
+- Optionally avoids re-picking any of the last `CACHE_SIZE` albums selected, remembered across runs, so consecutive invocations don't keep handing you the same few albums
+- Optional `-y`/`--year` filter to restrict selection to albums with a matching release year
 - Resolves every selected album *before* touching the existing queue -- nothing is modified until the whole selection succeeds (or degrades gracefully with `--force`)
 - Saves the original queue and playback state (random/repeat/single/consume, play state, song position) beforehand, and restores it automatically if anything fails partway through
 - Verifies the resulting queue actually contains what was intended before starting playback
@@ -24,9 +26,11 @@ mpd-random-album.sh [OPTIONS] [ALBUM_COUNT]
 
 | Option | Description |
 | --- | --- |
+| `-A`, `--allow-repeats` | Don't avoid recently-picked albums for this run, even if `AVOID_REPEATS` is on |
 | `-d`, `--dry-run` | Select and resolve albums without changing the queue |
 | `-f`, `--force` | Skip albums that fail to resolve instead of aborting the run |
 | `-q`, `--quiet` | Suppress informational messages |
+| `-y`, `--year YEAR` | Only select albums with a track dated `YEAR` (matches as a prefix, so `1975` also matches a full `1975-06-12`-style date) |
 | `-h`, `--help` | Show help |
 
 `ALBUM_COUNT` defaults to `DEFAULT_ALBUM_COUNT` from the config file if not given.
@@ -39,6 +43,8 @@ mpd-random-album.sh 5             # five random albums
 mpd-random-album.sh --quiet 3
 mpd-random-album.sh --dry-run 10
 mpd-random-album.sh --force 5     # don't abort if one of the 5 has vanished from the library
+mpd-random-album.sh --year 1975 3 # three random albums with a track dated 1975
+mpd-random-album.sh --allow-repeats 1  # force a pick even if the whole pool is "recent"
 ```
 
 ## Configuration
@@ -51,6 +57,8 @@ Settings live in `~/.config/mpd-scripts/mpd-random-album/mpd-random-album.conf`,
 | `QUIET` | Suppress informational messages by default | `false` |
 | `DRY_RUN` | Select/resolve without changing the queue, by default | `false` |
 | `FORCE` | Skip failed albums instead of aborting, by default | `false` |
+| `AVOID_REPEATS` | Avoid re-picking recently-selected albums by default | `true` |
+| `CACHE_SIZE` | How many recently-picked albums to remember and avoid | `20` |
 
 Each setting can still be overridden per invocation with its corresponding flag.
 
@@ -58,9 +66,19 @@ Each setting can still be overridden per invocation with its corresponding flag.
 
 By default, if a selected album can't be resolved (e.g. it was removed from the library between selection and resolution), the run **aborts** and the original queue/state is restored -- nothing is left half-changed. Pass `--force` (or set `FORCE=true` in the config) to skip unresolvable albums instead and continue with whatever did resolve, exiting `2` if that means fewer albums were added than requested.
 
+## Avoiding repeats
+
+When `AVOID_REPEATS` is on (the default), each run excludes the last `CACHE_SIZE` albums picked -- recorded in `~/.cache/mpd-scripts/mpd-random-album/recent-albums.tsv`, keyed by the same exact `(albumartist, album)` pair used for selection and resolution, so two different artists' albums that happen to share a title are never confused with each other in the exclusion history either.
+
+If excluding recent picks leaves too few albums to satisfy the requested count, that's treated exactly like an album vanishing from the library: it aborts and restores the original queue by default, or falls through to the usual partial-success/`--force` handling.
+
+`-A`/`--allow-repeats` skips the exclusion for a single run without touching the config -- useful if the pool is nearly exhausted, or you just want to deliberately hear something recent again. Recording still happens afterward regardless of `-A`, so a normal (non-`-A`) run right after still correctly treats that album as "just played" rather than forgetting about it. Only permanently disabling `AVOID_REPEATS` in the config stops recording entirely.
+
+A dry run (`-d`/`--dry-run`) never writes to the cache, since nothing was actually queued or played.
+
 ## Acknowledgments
 
-Derived from `RandAlbum` in [Alejandro-Roldan/mpc-scripts](https://github.com/Alejandro-Roldan/mpc-scripts).
+Derived from `RandAlbum` in [Alejandro-Roldan/mpc-scripts](https://github.com/Alejandro-Roldan/mpc-scripts). The recent-albums cache (`AVOID_REPEATS`/`CACHE_SIZE`/`-A`) was inspired by the equivalent feature in [ibeex/mpd_queue_random_album](https://github.com/ibeex/mpd_queue_random_album), reimplemented to key the cache by `(albumartist, album)` instead of the bare album title -- that project's version could conflate two different artists' albums sharing a common title (e.g. two unrelated "Greatest Hits") both in selection and in the recency cache, since it keyed and matched on album title alone.
 
 ## License
 

--- a/mpd-random-album/mpd-random-album.conf.example
+++ b/mpd-random-album/mpd-random-album.conf.example
@@ -26,3 +26,17 @@ DRY_RUN=false
 # false = abort on the first album that fails to resolve, by default
 # Can be overridden per invocation with -f/--force.
 FORCE=false
+
+# Avoid re-selecting any of the last CACHE_SIZE albums picked, remembered
+# across runs in ~/.cache/mpd-scripts/mpd-random-album/recent-albums.tsv.
+# true  = avoid recently-picked albums by default
+# false = every run is a fresh, unconstrained random pick
+# Can be overridden per invocation with -A/--allow-repeats (forces false).
+AVOID_REPEATS=true
+
+# How many of the most recently picked albums to remember and avoid, when
+# AVOID_REPEATS is on. If fewer non-recent albums remain in the library
+# than requested, this behaves like any other resolution shortfall --
+# reported via the same partial-success/--force handling as an album that
+# vanished from the library (see FORCE above).
+CACHE_SIZE=20

--- a/mpd-random-album/mpd-random-album.sh
+++ b/mpd-random-album/mpd-random-album.sh
@@ -4,19 +4,18 @@
 #
 # Script: mpd-random-album.sh
 #
-# Note: SC2317 ("unreachable" code) is disabled file-wide above because the
-# static analysis doesn't trace functions that are only ever invoked via
-# `trap` (restore_queue, handle_error, handle_signal, handle_int,
-# handle_term, cleanup) -- it otherwise flags their bodies as unreachable
-# even though they're the script's actual error/signal/exit handlers.
-#
 # Purpose:
 #   Clear the current MPD queue and replace it with a randomly selected
 #   collection of complete albums, then begin playback.
 #
 # Behavior:
 #   - Selects random unique album/album-artist combinations.
-#   - Uses exact album and album-artist matching when resolving albums.
+#   - Uses exact album and album-artist matching when resolving albums (and
+#     when excluding recently-picked ones), so two different artists'
+#     albums that happen to share a title are never conflated.
+#   - Optionally restricts selection to albums with a matching release year.
+#   - Optionally avoids re-selecting any of the last N albums picked,
+#     remembered across runs in a small cache file.
 #   - Resolves every selected album before modifying the queue.
 #   - Skips albums that disappear from the library between selection and
 #     resolution when --force is given; aborts the run otherwise.
@@ -35,6 +34,14 @@
 #   mpd-random-album.sh 5
 #   mpd-random-album.sh --quiet 3
 #   mpd-random-album.sh --dry-run 10
+#   mpd-random-album.sh --year 1975 5
+#   mpd-random-album.sh --allow-repeats 3
+#
+# Note: SC2317 ("unreachable" code) is disabled file-wide above because the
+# static analysis doesn't trace functions that are only ever invoked via
+# `trap` (restore_queue, handle_error, handle_signal, handle_int,
+# handle_term, cleanup) -- it otherwise flags their bodies as unreachable
+# even though they're the script's actual error/signal/exit handlers.
 #
 
 set -Eeuo pipefail
@@ -55,8 +62,21 @@ if [[ ! -f "$CONFIG_FILE" ]]; then
     cp "$(dirname "$0")/mpd-random-album.conf.example" "$CONFIG_FILE"
 fi
 
+# Defaults for settings that may not exist in a config predating them, so
+# an old config file (missing AVOID_REPEATS/CACHE_SIZE) doesn't trip set
+# -u's "unbound variable" instead of just falling back sensibly.
+AVOID_REPEATS=true
+CACHE_SIZE=20
+
 # shellcheck source=mpd-random-album.conf.example
 source "$CONFIG_FILE"
+
+# Recently-picked albums live here (not under ~/.config, since this is
+# regeneratable cache data rather than user configuration or critical
+# state) so AVOID_REPEATS can skip them on future runs. One
+# "albumartist\talbum" pair per line, oldest first.
+CACHE_DIR="$HOME/.cache/mpd-scripts/mpd-random-album"
+CACHE_FILE="$CACHE_DIR/recent-albums.tsv"
 
 # ---------------------------------------------------------------------------
 # Runtime state
@@ -330,10 +350,15 @@ Description:
   Replace the current MPD queue with randomly selected complete albums.
 
 Options:
-  -d, --dry-run    Select and resolve albums without changing the queue.
-  -f, --force      Skip albums that fail to resolve instead of aborting.
-  -h, --help       Show this help message.
-  -q, --quiet      Suppress informational messages.
+  -A, --allow-repeats  Don't avoid recently-picked albums for this run,
+                       even if AVOID_REPEATS is on in the config.
+  -d, --dry-run        Select and resolve albums without changing the queue.
+  -f, --force          Skip albums that fail to resolve instead of aborting.
+  -h, --help           Show this help message.
+  -q, --quiet          Suppress informational messages.
+  -y, --year YEAR      Only select albums with a track dated YEAR (matched
+                        as a prefix, so "1975" also matches a full date
+                        like "1975-06-12").
 
 Arguments:
   ALBUM_COUNT      Number of albums to select. Defaults to 1.
@@ -351,9 +376,21 @@ parse_arguments() {
     local album_count_set=false
 
     ALBUM_COUNT="$DEFAULT_ALBUM_COUNT"
+    YEAR_FILTER=""
+    ALLOW_REPEATS_OVERRIDE=false
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
+            -A|--allow-repeats)
+                # Deliberately does NOT touch AVOID_REPEATS itself -- that
+                # stays the persistent config value, so update_cache() still
+                # records this run's picks (see there for why: a forced
+                # repeat should still count as "just played" for the next,
+                # non-overridden run). Only select_random_albums()'s
+                # exclusion check consults this override.
+                ALLOW_REPEATS_OVERRIDE=true
+                shift
+                ;;
             -d|--dry-run)
                 DRY_RUN=true
                 shift
@@ -369,6 +406,13 @@ parse_arguments() {
             -q|--quiet)
                 QUIET=true
                 shift
+                ;;
+            -y|--year)
+                if [[ $# -lt 2 ]]; then
+                    error_exit "-y/--year requires an argument."
+                fi
+                YEAR_FILTER="$2"
+                shift 2
                 ;;
             --)
                 shift
@@ -395,6 +439,10 @@ parse_arguments() {
 
     if ! [[ "$ALBUM_COUNT" =~ ^[1-9][0-9]*$ ]]; then
         error_exit "Album count must be a positive integer."
+    fi
+
+    if [[ -n "$YEAR_FILTER" ]] && ! [[ "$YEAR_FILTER" =~ ^[0-9]{4}$ ]]; then
+        error_exit "-y/--year must be a 4-digit year, got '$YEAR_FILTER'."
     fi
 }
 
@@ -524,23 +572,54 @@ validate_album_record() {
 select_random_albums() {
     local album_count="$1"
     local album_record
+    local -a candidates=()
+    local excluded_recent=false
 
-    RANDOM_ALBUMS=()
-
-    mapfile -t RANDOM_ALBUMS < <(
-        mpc listall --format='%albumartist%\t%album%' |
-            awk -F '\t' '
-                NF == 2 &&
+    # %date% is always requested even when YEAR_FILTER is unset, so the
+    # same pipeline serves both cases; awk's (year == "" || ...) just
+    # always matches when there's no filter. index($3, year) == 1 is a
+    # prefix match rather than an exact one, so a filter of "1975" also
+    # matches a full "1975-06-12"-style date, without the substring-match
+    # false positives a plain "contains" search would have (a filter of
+    # "75" incorrectly matching "1975" via a bare index() > 0 check).
+    mapfile -t candidates < <(
+        mpc listall --format='%albumartist%\t%album%\t%date%' |
+            awk -F '\t' -v year="$YEAR_FILTER" '
+                NF >= 2 &&
                 $1 != "" &&
-                $2 != "" {
+                $2 != "" &&
+                (year == "" || index($3, year) == 1) {
                     print $1 "\t" $2
                 }
             ' |
-            sort -u |
-            shuf -n "$album_count"
+            sort -u
     )
 
+    # Excludes albums picked recently (see AVOID_REPEATS/-A/--allow-repeats
+    # and update_cache()) from the candidate pool before shuf ever sees it,
+    # rather than picking-and-retrying one at a time -- this can't loop
+    # indefinitely, and a pool that's shrunk too far to satisfy
+    # album_count falls straight through to the existing partial-success
+    # (or --force) handling exactly like an album vanishing from the
+    # library would.
+    if [[ "$AVOID_REPEATS" == true && "$ALLOW_REPEATS_OVERRIDE" != true && -s "$CACHE_FILE" && ${#candidates[@]} -gt 0 ]]; then
+        local -a filtered=()
+        mapfile -t filtered < <(printf '%s\n' "${candidates[@]}" | grep -vxFf "$CACHE_FILE" || true)
+        if [[ ${#filtered[@]} -lt ${#candidates[@]} ]]; then
+            excluded_recent=true
+        fi
+        candidates=("${filtered[@]}")
+    fi
+
+    RANDOM_ALBUMS=()
+    if [[ ${#candidates[@]} -gt 0 ]]; then
+        mapfile -t RANDOM_ALBUMS < <(printf '%s\n' "${candidates[@]}" | shuf -n "$album_count")
+    fi
+
     if [[ ${#RANDOM_ALBUMS[@]} -eq 0 ]]; then
+        if [[ "$excluded_recent" == true ]]; then
+            error_exit "No albums remain after excluding recently-picked ones. Use -A/--allow-repeats, lower CACHE_SIZE, or add more music."
+        fi
         error_exit "No valid albums were found in the MPD library."
     fi
 
@@ -706,6 +785,46 @@ start_playback() {
 }
 
 # ---------------------------------------------------------------------------
+# Recent-albums cache
+# ---------------------------------------------------------------------------
+
+#
+# Records this run's resolved albums as "recently picked" for AVOID_REPEATS
+# to exclude on future runs, trimming the cache to the last CACHE_SIZE
+# entries. Only called after a real (non-dry-run) run has actually changed
+# the queue, so a dry run or a failed run never pollutes it. A failure here
+# is reported but never fatal -- the queue/playback change it's recording
+# has already succeeded by the time this runs, and a stale/missing cache
+# file just means AVOID_REPEATS has less history to work with next time,
+# not a reason to make an otherwise-successful run exit non-zero.
+#
+update_cache() {
+    if [[ "$AVOID_REPEATS" != true ]]; then
+        return 0
+    fi
+
+    if ! [[ "$CACHE_SIZE" =~ ^[0-9]+$ ]]; then
+        warning_message "CACHE_SIZE in $CONFIG_FILE is invalid ('$CACHE_SIZE'); skipping recent-albums cache update."
+        return 0
+    fi
+
+    if (( CACHE_SIZE == 0 )); then
+        return 0
+    fi
+
+    mkdir -p "$CACHE_DIR"
+    touch "$CACHE_FILE"
+
+    local -a combined
+    mapfile -t combined < <(cat "$CACHE_FILE"; printf '%s\n' "${RESOLVED_ALBUMS[@]}")
+
+    local cache_tmp
+    cache_tmp="$(mktemp "${CACHE_FILE}.XXXXXX")"
+    printf '%s\n' "${combined[@]}" | tail -n "$CACHE_SIZE" > "$cache_tmp"
+    mv "$cache_tmp" "$CACHE_FILE"
+}
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
@@ -735,6 +854,7 @@ main() {
 
     clear_and_fill_queue
     start_playback
+    update_cache || warning_message "Failed to update the recent-albums cache."
 
     if (( resolved_album_count < requested_album_count )); then
         warning_message \


### PR DESCRIPTION
## Summary

**`AVOID_REPEATS`/`CACHE_SIZE`/`-A`/`--allow-repeats`**: avoids re-picking any of the last N albums selected, persisted across runs. Inspired by the equivalent feature in [ibeex/mpd_queue_random_album](https://github.com/ibeex/mpd_queue_random_album), but keyed by `(albumartist, album)` instead of bare album title -- that project's version could conflate two different artists' albums sharing a title (e.g. two unrelated "Greatest Hits") both during selection and in the recency cache. Reuses the exact-match pairs this script already uses for selection/resolution, so the fix falls out naturally.

A pool too small to satisfy the requested count after exclusion is treated exactly like an album vanishing from the library (abort + restore by default, or the existing partial-success/`--force` handling). Cache recording only happens after a real (non-dry-run) queue change succeeds, and a recording failure is reported but never fatal.

**`-y`/`--year YEAR`**: restricts selection to albums with a track dated `YEAR`, matched as a prefix against MPD's `date` tag (so it still matches a full `YYYY-MM-DD` date) -- avoiding the substring-match over-matching (`"201"` matching all of 2010-2019) that `mpd_queue_random_album`'s equivalent has from using `searchadd` instead.

**Bug caught and fixed during my own testing**: `-A/--allow-repeats` initially mutated `AVOID_REPEATS` directly, which meant a forced repeat also silently skipped being recorded into the cache -- so a normal run right after wouldn't know that album was just played. Split into a separate override that only affects that one run's selection; recording now always follows the persistent config setting regardless of `-A`.

**Deliberately not ported**: `mpd_queue_random_album`'s `current` subcommand (enqueue the currently-playing album) doesn't fit this tool's "clear and replace with random albums" scope.

## Test plan
- [x] `shellcheck` clean
- [x] Regression: full random selection unchanged, same-titled-different-artist albums still resolved separately
- [x] Cycled through a 5-album test library with zero repeats until the pool exhausted, then got a clean, actionable error
- [x] `CACHE_SIZE` trimming verified
- [x] Dry-run confirmed to never write the cache
- [x] `-y`/`--year` verified to only select matching albums, including the full-date prefix-match case
- [x] The `-A` recording bug reproduced, fixed, and reverified (forced pick still appears in the cache afterward)
- [x] Config predating these settings (missing `AVOID_REPEATS`/`CACHE_SIZE`) confirmed not to crash under `set -u`
- [x] Malformed `CACHE_SIZE` confirmed to warn and skip the cache update rather than crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)