### PR TITLE
mpd-random-album: genre/artist filters, append mode, notification hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Collection of scripts related to mpd & mpc.
 | **[rm-artists-playlist](./rm-artists-playlist/)** | Removes songs by a list of artists from a saved MPD playlist or the current queue, or lists available playlists. |
 | **[mpd-add-random-artist](./mpd-add-random-artist/)** | Adds a random sample of a specified artist's tracks to the current MPD queue, matching exactly by default or loosely with `-l`. |
 | **[mpd-add-random](./mpd-add-random/)** | Adds a random selection of tracks from the local music library to the current MPD queue. |
-| **[mpd-random-album](./mpd-random-album/)** | Clears the queue and replaces it with randomly selected complete albums, with an optional year filter, a recent-picks cache to avoid repeats, saving and restoring the original queue/state if anything fails. |
+| **[mpd-random-album](./mpd-random-album/)** | Clears the queue (or appends to it) and fills it with randomly selected complete albums, with optional year/genre/artist filters, a recent-picks cache to avoid repeats, a notification hook, and saving/restoring the original queue/state if anything fails. |
 | **[add-current-song](./add-current-song/)** | Adds the currently playing MPD song to an M3U playlist, with duplicate prevention, sorting, locking, and atomic rewrites. |
 | **[mpd-tray-icon](./mpd-tray-icon/)** | A GTK3 tray icon showing the currently playing MPD track, with Play/Pause/Next/Previous controls. |
 | **[mpd-radio-tray](./mpd-radio-tray/)** | A PyQt5 system tray app for managing and playing categorized internet radio station URLs with MPD, similar to RadioTray-NG. |

--- a/mpd-random-album/README.md
+++ b/mpd-random-album/README.md
@@ -9,6 +9,7 @@ Clears the current MPD queue and replaces it with a randomly selected collection
 - Optional `-y`/`--year` filter to restrict selection to albums with a track dated a given year, or within a year range
 - Optional `-g`/`--genre` filter (case-insensitive substring match) to restrict selection to a genre
 - Optional `-a`/`--artist` filter (exact match) to restrict selection to a specific album artist
+- Optional `-p`/`--append` mode adds the selected albums to the end of the existing queue instead of replacing it, without disturbing current playback
 - Resolves every selected album *before* touching the existing queue -- nothing is modified until the whole selection succeeds (or degrades gracefully with `--force`)
 - Saves the original queue and playback state (random/repeat/single/consume, play state, song position) beforehand, and restores it automatically if anything fails partway through
 - Verifies the resulting queue actually contains what was intended before starting playback
@@ -33,6 +34,7 @@ mpd-random-album.sh [OPTIONS] [ALBUM_COUNT]
 | `-d`, `--dry-run` | Select and resolve albums without changing the queue |
 | `-f`, `--force` | Skip albums that fail to resolve instead of aborting the run |
 | `-g`, `--genre GENRE` | Only select albums with a track whose genre contains `GENRE` (case insensitive) |
+| `-p`, `--append` | Add the selected albums to the end of the existing queue instead of replacing it, without disturbing current playback |
 | `-q`, `--quiet` | Suppress informational messages |
 | `-y`, `--year YEAR` | Only select albums with a track dated `YEAR`, or a `YEAR-YEAR` range (e.g. `1970-1979`); a full `1975-06-12`-style date still matches a bare `1975` |
 | `-h`, `--help` | Show help |
@@ -51,6 +53,7 @@ mpd-random-album.sh --year 1975 3      # three random albums with a track dated 
 mpd-random-album.sh --year 1970-1979 3 # three random albums from that decade
 mpd-random-album.sh --genre jazz 3     # three random albums tagged (or containing) "jazz"
 mpd-random-album.sh --artist "Pink Floyd" 2 # two random albums by exactly "Pink Floyd"
+mpd-random-album.sh --append 2         # add two random albums to the end of the queue, keep playing
 mpd-random-album.sh --allow-repeats 1  # force a pick even if the whole pool is "recent"
 ```
 
@@ -66,6 +69,7 @@ Settings live in `~/.config/mpd-scripts/mpd-random-album/mpd-random-album.conf`,
 | `FORCE` | Skip failed albums instead of aborting, by default | `false` |
 | `AVOID_REPEATS` | Avoid re-picking recently-selected albums by default | `true` |
 | `CACHE_SIZE` | How many recently-picked albums to remember and avoid | `20` |
+| `APPEND` | Add to the end of the existing queue instead of replacing it, by default | `false` |
 
 Each setting can still be overridden per invocation with its corresponding flag.
 
@@ -82,6 +86,12 @@ If excluding recent picks leaves too few albums to satisfy the requested count, 
 `-A`/`--allow-repeats` skips the exclusion for a single run without touching the config -- useful if the pool is nearly exhausted, or you just want to deliberately hear something recent again. Recording still happens afterward regardless of `-A`, so a normal (non-`-A`) run right after still correctly treats that album as "just played" rather than forgetting about it. Only permanently disabling `AVOID_REPEATS` in the config stops recording entirely.
 
 A dry run (`-d`/`--dry-run`) never writes to the cache, since nothing was actually queued or played.
+
+## Append mode
+
+`-p`/`--append` (or `APPEND=true` in the config) adds the selected albums to the end of the existing queue instead of clearing and replacing it. Unlike the default mode, it never touches playback, the current song, or the random/repeat/single/consume settings -- it's meant for topping up the queue in the background without interrupting whatever's currently playing.
+
+If a track fails to add partway through, only the tracks this run itself appended are removed; the pre-existing queue and playback are left exactly as they were, same as the default mode's own restore-on-failure guarantee.
 
 ## Acknowledgments
 

--- a/mpd-random-album/README.md
+++ b/mpd-random-album/README.md
@@ -10,6 +10,7 @@ Clears the current MPD queue and replaces it with a randomly selected collection
 - Optional `-g`/`--genre` filter (case-insensitive substring match) to restrict selection to a genre
 - Optional `-a`/`--artist` filter (exact match) to restrict selection to a specific album artist
 - Optional `-p`/`--append` mode adds the selected albums to the end of the existing queue instead of replacing it, without disturbing current playback
+- Optional `SELECTION_HOOK` shell command, run after a successful selection (e.g. to send a desktop notification)
 - Resolves every selected album *before* touching the existing queue -- nothing is modified until the whole selection succeeds (or degrades gracefully with `--force`)
 - Saves the original queue and playback state (random/repeat/single/consume, play state, song position) beforehand, and restores it automatically if anything fails partway through
 - Verifies the resulting queue actually contains what was intended before starting playback
@@ -70,6 +71,7 @@ Settings live in `~/.config/mpd-scripts/mpd-random-album/mpd-random-album.conf`,
 | `AVOID_REPEATS` | Avoid re-picking recently-selected albums by default | `true` |
 | `CACHE_SIZE` | How many recently-picked albums to remember and avoid | `20` |
 | `APPEND` | Add to the end of the existing queue instead of replacing it, by default | `false` |
+| `SELECTION_HOOK` | Shell command run after a successful selection | *(none)* |
 
 Each setting can still be overridden per invocation with its corresponding flag.
 
@@ -92,6 +94,23 @@ A dry run (`-d`/`--dry-run`) never writes to the cache, since nothing was actual
 `-p`/`--append` (or `APPEND=true` in the config) adds the selected albums to the end of the existing queue instead of clearing and replacing it. Unlike the default mode, it never touches playback, the current song, or the random/repeat/single/consume settings -- it's meant for topping up the queue in the background without interrupting whatever's currently playing.
 
 If a track fails to add partway through, only the tracks this run itself appended are removed; the pre-existing queue and playback are left exactly as they were, same as the default mode's own restore-on-failure guarantee.
+
+## Notification hook
+
+`SELECTION_HOOK` in the config runs an arbitrary shell command after a successful (or partially successful) selection -- fire-and-forget and never fatal, the same pattern used by [`alarmpd`](../alarmpd/) and [`mpd-auto-stop`](../mpd-auto-stop/) elsewhere in this repo. Leave it blank (the default) to disable it. A dry run never fires it, since nothing was actually selected for real.
+
+What was selected is passed via environment variables rather than arguments, so the hook command doesn't need its own argument parsing:
+
+| Variable | Description |
+| --- | --- |
+| `MPD_RANDOM_ALBUM_ALBUMS` | Newline-separated `Artist - Album` list |
+| `MPD_RANDOM_ALBUM_ALBUM_COUNT` | Number of albums selected |
+| `MPD_RANDOM_ALBUM_TRACK_COUNT` | Number of tracks selected |
+| `MPD_RANDOM_ALBUM_MODE` | `replace` or `append` |
+
+```
+SELECTION_HOOK='notify-send "MPD" "$MPD_RANDOM_ALBUM_ALBUMS"'
+```
 
 ## Acknowledgments
 

--- a/mpd-random-album/README.md
+++ b/mpd-random-album/README.md
@@ -7,6 +7,7 @@ Clears the current MPD queue and replaces it with a randomly selected collection
 - Selects random unique album/album-artist combinations, using exact matching (`mpc find`, not `mpc search`) so similarly-named albums (e.g. `The Wall` vs. `The Wall (Remastered)`) don't get conflated -- including two *different artists'* albums that happen to share a title (e.g. two unrelated "Greatest Hits"), which are kept fully separate rather than treated as duplicates
 - Optionally avoids re-picking any of the last `CACHE_SIZE` albums selected, remembered across runs, so consecutive invocations don't keep handing you the same few albums
 - Optional `-y`/`--year` filter to restrict selection to albums with a track dated a given year, or within a year range
+- Optional `-g`/`--genre` filter (case-insensitive substring match) to restrict selection to a genre
 - Resolves every selected album *before* touching the existing queue -- nothing is modified until the whole selection succeeds (or degrades gracefully with `--force`)
 - Saves the original queue and playback state (random/repeat/single/consume, play state, song position) beforehand, and restores it automatically if anything fails partway through
 - Verifies the resulting queue actually contains what was intended before starting playback
@@ -29,6 +30,7 @@ mpd-random-album.sh [OPTIONS] [ALBUM_COUNT]
 | `-A`, `--allow-repeats` | Don't avoid recently-picked albums for this run, even if `AVOID_REPEATS` is on |
 | `-d`, `--dry-run` | Select and resolve albums without changing the queue |
 | `-f`, `--force` | Skip albums that fail to resolve instead of aborting the run |
+| `-g`, `--genre GENRE` | Only select albums with a track whose genre contains `GENRE` (case insensitive) |
 | `-q`, `--quiet` | Suppress informational messages |
 | `-y`, `--year YEAR` | Only select albums with a track dated `YEAR`, or a `YEAR-YEAR` range (e.g. `1970-1979`); a full `1975-06-12`-style date still matches a bare `1975` |
 | `-h`, `--help` | Show help |
@@ -45,6 +47,7 @@ mpd-random-album.sh --dry-run 10
 mpd-random-album.sh --force 5     # don't abort if one of the 5 has vanished from the library
 mpd-random-album.sh --year 1975 3      # three random albums with a track dated 1975
 mpd-random-album.sh --year 1970-1979 3 # three random albums from that decade
+mpd-random-album.sh --genre jazz 3     # three random albums tagged (or containing) "jazz"
 mpd-random-album.sh --allow-repeats 1  # force a pick even if the whole pool is "recent"
 ```
 

--- a/mpd-random-album/README.md
+++ b/mpd-random-album/README.md
@@ -8,6 +8,7 @@ Clears the current MPD queue and replaces it with a randomly selected collection
 - Optionally avoids re-picking any of the last `CACHE_SIZE` albums selected, remembered across runs, so consecutive invocations don't keep handing you the same few albums
 - Optional `-y`/`--year` filter to restrict selection to albums with a track dated a given year, or within a year range
 - Optional `-g`/`--genre` filter (case-insensitive substring match) to restrict selection to a genre
+- Optional `-a`/`--artist` filter (exact match) to restrict selection to a specific album artist
 - Resolves every selected album *before* touching the existing queue -- nothing is modified until the whole selection succeeds (or degrades gracefully with `--force`)
 - Saves the original queue and playback state (random/repeat/single/consume, play state, song position) beforehand, and restores it automatically if anything fails partway through
 - Verifies the resulting queue actually contains what was intended before starting playback
@@ -28,6 +29,7 @@ mpd-random-album.sh [OPTIONS] [ALBUM_COUNT]
 | Option | Description |
 | --- | --- |
 | `-A`, `--allow-repeats` | Don't avoid recently-picked albums for this run, even if `AVOID_REPEATS` is on |
+| `-a`, `--artist ARTIST` | Only select albums by `ARTIST` (exact match against the album artist) |
 | `-d`, `--dry-run` | Select and resolve albums without changing the queue |
 | `-f`, `--force` | Skip albums that fail to resolve instead of aborting the run |
 | `-g`, `--genre GENRE` | Only select albums with a track whose genre contains `GENRE` (case insensitive) |
@@ -48,6 +50,7 @@ mpd-random-album.sh --force 5     # don't abort if one of the 5 has vanished fro
 mpd-random-album.sh --year 1975 3      # three random albums with a track dated 1975
 mpd-random-album.sh --year 1970-1979 3 # three random albums from that decade
 mpd-random-album.sh --genre jazz 3     # three random albums tagged (or containing) "jazz"
+mpd-random-album.sh --artist "Pink Floyd" 2 # two random albums by exactly "Pink Floyd"
 mpd-random-album.sh --allow-repeats 1  # force a pick even if the whole pool is "recent"
 ```
 

--- a/mpd-random-album/mpd-random-album.conf.example
+++ b/mpd-random-album/mpd-random-album.conf.example
@@ -40,3 +40,11 @@ AVOID_REPEATS=true
 # reported via the same partial-success/--force handling as an album that
 # vanished from the library (see FORCE above).
 CACHE_SIZE=20
+
+# Add selected albums to the end of the existing queue instead of clearing
+# and replacing it, by default. Never touches playback, the current song,
+# or the random/repeat/single/consume settings.
+# true  = append to the queue by default
+# false = clear and replace the queue by default
+# Can be overridden per invocation with -p/--append.
+APPEND=false

--- a/mpd-random-album/mpd-random-album.conf.example
+++ b/mpd-random-album/mpd-random-album.conf.example
@@ -48,3 +48,15 @@ CACHE_SIZE=20
 # false = clear and replace the queue by default
 # Can be overridden per invocation with -p/--append.
 APPEND=false
+
+# Optional shell command run after a successful (or partially successful)
+# selection, e.g. to send a desktop notification. Fire-and-forget and
+# never fatal -- a missing/broken hook has no effect on the run itself.
+# Leave blank to disable (the default). Details about what was selected
+# are passed via environment variables rather than arguments:
+#   MPD_RANDOM_ALBUM_ALBUMS       newline-separated "Artist - Album" list
+#   MPD_RANDOM_ALBUM_ALBUM_COUNT  number of albums selected
+#   MPD_RANDOM_ALBUM_TRACK_COUNT  number of tracks selected
+#   MPD_RANDOM_ALBUM_MODE         "replace" or "append"
+# Example: SELECTION_HOOK='notify-send "MPD" "$MPD_RANDOM_ALBUM_ALBUMS"'
+SELECTION_HOOK=

--- a/mpd-random-album/mpd-random-album.sh
+++ b/mpd-random-album/mpd-random-album.sh
@@ -14,8 +14,8 @@
 #     when excluding recently-picked ones), so two different artists'
 #     albums that happen to share a title are never conflated.
 #   - Optionally restricts selection to albums with a track dated within a
-#     given year or year range, and/or matching a genre (substring, case
-#     insensitive).
+#     given year or year range, matching a genre (substring, case
+#     insensitive), and/or by a specific album artist (exact match).
 #   - Optionally avoids re-selecting any of the last N albums picked,
 #     remembered across runs in a small cache file.
 #   - Resolves every selected album before modifying the queue.
@@ -39,6 +39,7 @@
 #   mpd-random-album.sh --year 1975 5
 #   mpd-random-album.sh --year 1970-1979 5
 #   mpd-random-album.sh --genre jazz 3
+#   mpd-random-album.sh --artist "Pink Floyd" 2
 #   mpd-random-album.sh --allow-repeats 3
 #
 # Note: SC2317 ("unreachable" code) is disabled file-wide above because the
@@ -356,6 +357,8 @@ Description:
 Options:
   -A, --allow-repeats  Don't avoid recently-picked albums for this run,
                        even if AVOID_REPEATS is on in the config.
+  -a, --artist ARTIST  Only select albums by ARTIST (exact match against
+                       the album artist).
   -d, --dry-run        Select and resolve albums without changing the queue.
   -f, --force          Skip albums that fail to resolve instead of aborting.
   -g, --genre GENRE    Only select albums with a track whose genre
@@ -383,6 +386,7 @@ parse_arguments() {
     ALBUM_COUNT="$DEFAULT_ALBUM_COUNT"
     YEAR_FILTER=""
     GENRE_FILTER=""
+    ARTIST_FILTER=""
     ALLOW_REPEATS_OVERRIDE=false
 
     while [[ $# -gt 0 ]]; do
@@ -396,6 +400,13 @@ parse_arguments() {
                 # exclusion check consults this override.
                 ALLOW_REPEATS_OVERRIDE=true
                 shift
+                ;;
+            -a|--artist)
+                if [[ $# -lt 2 ]]; then
+                    error_exit "-a/--artist requires an argument."
+                fi
+                ARTIST_FILTER="$2"
+                shift 2
                 ;;
             -d|--dry-run)
                 DRY_RUN=true
@@ -634,9 +645,13 @@ select_random_albums() {
     # sidesteps any regex-metacharacter surprises from an arbitrary
     # user-supplied genre string, the same reasoning the year filter
     # originally used it for before it needed numeric range comparison.
+    #
+    # Artist matching (-a/--artist) is the opposite deliberately: an exact
+    # match against $1, consistent with how album/albumartist identity is
+    # always treated exactly everywhere else in this script.
     mapfile -t candidates < <(
         mpc listall --format='%albumartist%\t%album%\t%date%\t%genre%' |
-            awk -F '\t' -v start="$YEAR_START" -v end="$YEAR_END" -v genre="${GENRE_FILTER,,}" '
+            awk -F '\t' -v start="$YEAR_START" -v end="$YEAR_END" -v genre="${GENRE_FILTER,,}" -v artist="$ARTIST_FILTER" '
                 NF >= 2 &&
                 $1 != "" &&
                 $2 != "" &&
@@ -644,7 +659,8 @@ select_random_albums() {
                     (substr($3, 1, 4) ~ /^[0-9][0-9][0-9][0-9]$/ &&
                      substr($3, 1, 4) + 0 >= start + 0 &&
                      substr($3, 1, 4) + 0 <= end + 0)) &&
-                (genre == "" || index(tolower($4), genre) > 0) {
+                (genre == "" || index(tolower($4), genre) > 0) &&
+                (artist == "" || $1 == artist) {
                     print $1 "\t" $2
                 }
             ' |

--- a/mpd-random-album/mpd-random-album.sh
+++ b/mpd-random-album/mpd-random-album.sh
@@ -21,6 +21,8 @@
 #   - Optional --append mode adds the selected albums to the end of the
 #     existing queue instead of replacing it, without disturbing whatever
 #     is currently playing.
+#   - Optionally runs a SELECTION_HOOK shell command (from the config)
+#     after a successful selection, e.g. to send a desktop notification.
 #   - Resolves every selected album before modifying the queue.
 #   - Skips albums that disappear from the library between selection and
 #     resolution when --force is given; aborts the run otherwise.
@@ -72,11 +74,13 @@ if [[ ! -f "$CONFIG_FILE" ]]; then
 fi
 
 # Defaults for settings that may not exist in a config predating them, so
-# an old config file (missing AVOID_REPEATS/CACHE_SIZE/APPEND) doesn't
-# trip set -u's "unbound variable" instead of just falling back sensibly.
+# an old config file (missing AVOID_REPEATS/CACHE_SIZE/APPEND/
+# SELECTION_HOOK) doesn't trip set -u's "unbound variable" instead of just
+# falling back sensibly.
 AVOID_REPEATS=true
 CACHE_SIZE=20
 APPEND=false
+SELECTION_HOOK=""
 
 # shellcheck source=mpd-random-album.conf.example
 source "$CONFIG_FILE"
@@ -978,6 +982,48 @@ update_cache() {
 }
 
 # ---------------------------------------------------------------------------
+# Selection hook
+# ---------------------------------------------------------------------------
+
+#
+# Runs the optional SELECTION_HOOK shell command from the config after a
+# successful (or partially successful) selection -- e.g. to send a desktop
+# notification. Fire-and-forget and never fatal, matching the same
+# shell-hook pattern used by alarmpd/mpd-auto-stop elsewhere in this repo.
+# Selection details are exported as environment variables rather than
+# passed as arguments, so a hook command doesn't need its own argument
+# parsing to read them.
+#
+run_selection_hook() {
+    local album_record
+    local album_artist
+    local album
+    local mode
+    local -a album_lines=()
+
+    if [[ -z "$SELECTION_HOOK" ]]; then
+        return 0
+    fi
+
+    for album_record in "${RESOLVED_ALBUMS[@]}"; do
+        album_artist="${album_record%%$'\t'*}"
+        album="${album_record#*$'\t'}"
+        album_lines+=("$album_artist - $album")
+    done
+
+    mode="replace"
+    if [[ "$APPEND" == true ]]; then
+        mode="append"
+    fi
+
+    MPD_RANDOM_ALBUM_ALBUMS="$(printf '%s\n' "${album_lines[@]}")" \
+    MPD_RANDOM_ALBUM_ALBUM_COUNT="${#RESOLVED_ALBUMS[@]}" \
+    MPD_RANDOM_ALBUM_TRACK_COUNT="${#SELECTED_TRACKS[@]}" \
+    MPD_RANDOM_ALBUM_MODE="$mode" \
+        bash -c "$SELECTION_HOOK" >/dev/null 2>&1 &
+}
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
@@ -1014,6 +1060,7 @@ main() {
     fi
 
     update_cache || warning_message "Failed to update the recent-albums cache."
+    run_selection_hook
 
     if (( resolved_album_count < requested_album_count )); then
         warning_message \

--- a/mpd-random-album/mpd-random-album.sh
+++ b/mpd-random-album/mpd-random-album.sh
@@ -18,6 +18,9 @@
 #     insensitive), and/or by a specific album artist (exact match).
 #   - Optionally avoids re-selecting any of the last N albums picked,
 #     remembered across runs in a small cache file.
+#   - Optional --append mode adds the selected albums to the end of the
+#     existing queue instead of replacing it, without disturbing whatever
+#     is currently playing.
 #   - Resolves every selected album before modifying the queue.
 #   - Skips albums that disappear from the library between selection and
 #     resolution when --force is given; aborts the run otherwise.
@@ -40,6 +43,7 @@
 #   mpd-random-album.sh --year 1970-1979 5
 #   mpd-random-album.sh --genre jazz 3
 #   mpd-random-album.sh --artist "Pink Floyd" 2
+#   mpd-random-album.sh --append 2
 #   mpd-random-album.sh --allow-repeats 3
 #
 # Note: SC2317 ("unreachable" code) is disabled file-wide above because the
@@ -68,10 +72,11 @@ if [[ ! -f "$CONFIG_FILE" ]]; then
 fi
 
 # Defaults for settings that may not exist in a config predating them, so
-# an old config file (missing AVOID_REPEATS/CACHE_SIZE) doesn't trip set
-# -u's "unbound variable" instead of just falling back sensibly.
+# an old config file (missing AVOID_REPEATS/CACHE_SIZE/APPEND) doesn't
+# trip set -u's "unbound variable" instead of just falling back sensibly.
 AVOID_REPEATS=true
 CACHE_SIZE=20
+APPEND=false
 
 # shellcheck source=mpd-random-album.conf.example
 source "$CONFIG_FILE"
@@ -97,6 +102,7 @@ ORIGINAL_SINGLE=""
 ORIGINAL_CONSUME=""
 ORIGINAL_STATE=""
 ORIGINAL_SONG_POSITION=""
+APPEND_START_LENGTH=0
 
 declare -a ORIGINAL_QUEUE=()
 declare -a RANDOM_ALBUMS=()
@@ -140,6 +146,29 @@ restore_queue() {
     # the error handler.
     #
     trap - ERR
+
+    if [[ "$APPEND" == true ]]; then
+        #
+        # Append mode never cleared the queue or touched playback, so
+        # there's nothing to restore beyond removing whatever this run
+        # itself appended. Repeatedly deleting the position right after the
+        # pre-append queue length removes exactly the appended block: each
+        # deletion shifts the next appended track down into that same
+        # position. Deleting past the current queue end (e.g. because fewer
+        # tracks were actually appended than SELECTED_TRACKS expected) just
+        # fails, caught by "|| true" like every other command here.
+        #
+        local i
+        for ((i = 0; i < ${#SELECTED_TRACKS[@]}; i++)); do
+            mpc del "$((APPEND_START_LENGTH + 1))" >/dev/null 2>&1 || true
+        done
+
+        QUEUE_MODIFIED=false
+        RESTORING_QUEUE=false
+
+        trap handle_error ERR
+        return 0
+    fi
 
     mpc stop >/dev/null 2>&1 || true
     mpc clear >/dev/null 2>&1 || true
@@ -364,6 +393,9 @@ Options:
   -g, --genre GENRE    Only select albums with a track whose genre
                        contains GENRE (case insensitive).
   -h, --help           Show this help message.
+  -p, --append         Add the selected albums to the end of the existing
+                       queue instead of replacing it, without disturbing
+                       current playback.
   -q, --quiet          Suppress informational messages.
   -y, --year YEAR      Only select albums with a track dated YEAR, or
                         within a YEAR-YEAR range (e.g. 1970-1979).
@@ -426,6 +458,10 @@ parse_arguments() {
             -h|--help)
                 show_help
                 exit 0
+                ;;
+            -p|--append)
+                APPEND=true
+                shift
                 ;;
             -q|--quiet)
                 QUIET=true
@@ -812,6 +848,27 @@ clear_and_fill_queue() {
     done
 }
 
+#
+# Append mode (-p/--append): add the selected tracks to the end of the
+# existing queue instead of replacing it. Unlike clear_and_fill_queue(),
+# this never clears the queue, never touches random/repeat/single/consume,
+# and never starts or otherwise disturbs current playback -- the whole
+# point of append mode is to top up the queue in the background.
+#
+append_to_queue() {
+    local track
+
+    APPEND_START_LENGTH="$(verify_queue)"
+
+    QUEUE_MODIFIED=true
+
+    for track in "${SELECTED_TRACKS[@]}"; do
+        if ! mpc add -- "$track" >/dev/null; then
+            error_exit "Unable to add track to MPD queue: $track"
+        fi
+    done
+}
+
 # ---------------------------------------------------------------------------
 # Final validation and playback
 # ---------------------------------------------------------------------------
@@ -852,6 +909,30 @@ start_playback() {
             fi
             ;;
     esac
+
+    QUEUE_MODIFIED=false
+}
+
+#
+# Verify and report an append-mode run. Unlike start_playback(), the
+# expected queue length is the pre-append length plus what was just added
+# (not just the added count on its own, since the existing queue was never
+# cleared), and playback is deliberately left untouched.
+#
+verify_and_report_append() {
+    local queue_length
+    local expected_length
+
+    queue_length="$(verify_queue)"
+    expected_length=$((APPEND_START_LENGTH + ${#SELECTED_TRACKS[@]}))
+
+    if (( queue_length != expected_length )); then
+        error_exit \
+            "Queue verification failed: expected $expected_length track(s), found $queue_length."
+    fi
+
+    log_message \
+        "Added ${#RESOLVED_ALBUMS[@]} random album(s) containing ${#SELECTED_TRACKS[@]} track(s) to the queue."
 
     QUEUE_MODIFIED=false
 }
@@ -924,8 +1005,14 @@ main() {
         return 0
     fi
 
-    clear_and_fill_queue
-    start_playback
+    if [[ "$APPEND" == true ]]; then
+        append_to_queue
+        verify_and_report_append
+    else
+        clear_and_fill_queue
+        start_playback
+    fi
+
     update_cache || warning_message "Failed to update the recent-albums cache."
 
     if (( resolved_album_count < requested_album_count )); then
@@ -935,7 +1022,9 @@ main() {
         return 2
     fi
 
-    log_message "Playback started successfully."
+    if [[ "$APPEND" != true ]]; then
+        log_message "Playback started successfully."
+    fi
 
     return 0
 }

--- a/mpd-random-album/mpd-random-album.sh
+++ b/mpd-random-album/mpd-random-album.sh
@@ -14,7 +14,8 @@
 #     when excluding recently-picked ones), so two different artists'
 #     albums that happen to share a title are never conflated.
 #   - Optionally restricts selection to albums with a track dated within a
-#     given year or year range.
+#     given year or year range, and/or matching a genre (substring, case
+#     insensitive).
 #   - Optionally avoids re-selecting any of the last N albums picked,
 #     remembered across runs in a small cache file.
 #   - Resolves every selected album before modifying the queue.
@@ -37,6 +38,7 @@
 #   mpd-random-album.sh --dry-run 10
 #   mpd-random-album.sh --year 1975 5
 #   mpd-random-album.sh --year 1970-1979 5
+#   mpd-random-album.sh --genre jazz 3
 #   mpd-random-album.sh --allow-repeats 3
 #
 # Note: SC2317 ("unreachable" code) is disabled file-wide above because the
@@ -356,6 +358,8 @@ Options:
                        even if AVOID_REPEATS is on in the config.
   -d, --dry-run        Select and resolve albums without changing the queue.
   -f, --force          Skip albums that fail to resolve instead of aborting.
+  -g, --genre GENRE    Only select albums with a track whose genre
+                       contains GENRE (case insensitive).
   -h, --help           Show this help message.
   -q, --quiet          Suppress informational messages.
   -y, --year YEAR      Only select albums with a track dated YEAR, or
@@ -378,6 +382,7 @@ parse_arguments() {
 
     ALBUM_COUNT="$DEFAULT_ALBUM_COUNT"
     YEAR_FILTER=""
+    GENRE_FILTER=""
     ALLOW_REPEATS_OVERRIDE=false
 
     while [[ $# -gt 0 ]]; do
@@ -399,6 +404,13 @@ parse_arguments() {
             -f|--force)
                 FORCE=true
                 shift
+                ;;
+            -g|--genre)
+                if [[ $# -lt 2 ]]; then
+                    error_exit "-g/--genre requires an argument."
+                fi
+                GENRE_FILTER="$2"
+                shift 2
                 ;;
             -h|--help)
                 show_help
@@ -612,16 +624,27 @@ select_random_albums() {
     # brace-interval regex syntax and silently matches nothing with it,
     # unlike bash's own =~ used for the same 4-digit check elsewhere in
     # this script, which has no such limitation.
+    #
+    # Genre matching (-g/--genre) is deliberately a case-insensitive
+    # substring match via index(), not the exact matching used for
+    # album/albumartist -- genre tagging is inherently loose and
+    # inconsistent across libraries ("Rock" vs. "Classic Rock" vs.
+    # "rock"), unlike album/artist identity, where exact matching is what
+    # prevents two different things from being conflated. index() also
+    # sidesteps any regex-metacharacter surprises from an arbitrary
+    # user-supplied genre string, the same reasoning the year filter
+    # originally used it for before it needed numeric range comparison.
     mapfile -t candidates < <(
-        mpc listall --format='%albumartist%\t%album%\t%date%' |
-            awk -F '\t' -v start="$YEAR_START" -v end="$YEAR_END" '
+        mpc listall --format='%albumartist%\t%album%\t%date%\t%genre%' |
+            awk -F '\t' -v start="$YEAR_START" -v end="$YEAR_END" -v genre="${GENRE_FILTER,,}" '
                 NF >= 2 &&
                 $1 != "" &&
                 $2 != "" &&
                 (start == "" ||
                     (substr($3, 1, 4) ~ /^[0-9][0-9][0-9][0-9]$/ &&
                      substr($3, 1, 4) + 0 >= start + 0 &&
-                     substr($3, 1, 4) + 0 <= end + 0)) {
+                     substr($3, 1, 4) + 0 <= end + 0)) &&
+                (genre == "" || index(tolower($4), genre) > 0) {
                     print $1 "\t" $2
                 }
             ' |


### PR DESCRIPTION
## Summary
- Add `-g`/`--genre` filter (case-insensitive substring match)
- Add `-a`/`--artist` filter (exact match against album artist)
- Add `-p`/`--append` mode: add selected albums to the end of the existing queue instead of clearing/replacing it, without disturbing current playback, random/repeat/single/consume, or the current song. Restores only the tracks it itself appended if a failure occurs partway through.
- Add `SELECTION_HOOK` config setting: optional fire-and-forget shell command run after a successful selection (e.g. for a desktop notification), matching the hook pattern used by `alarmpd`/`mpd-auto-stop` elsewhere in this repo. Selection details are exposed via `MPD_RANDOM_ALBUM_*` environment variables.
- Update `mpd-random-album/README.md` and `mpd-random-album.conf.example` for all of the above, and refresh the top-level README's one-line summary of the tool.

Also fixes a bug caught during testing: `main()` unconditionally logged "Playback started successfully." even in append mode, which never starts or touches playback.

## Test plan
- [x] `bash -n` and `shellcheck` clean on `mpd-random-album.sh` (only pre-existing `SC1091` info note)
- [x] Manual testing via a stateful fake `mpc` harness for each feature: genre filter, artist filter (including exact-match distinguishing two different artists' same-titled albums), append mode (normal append, mid-failure restore-only-appended-tracks, config-default `APPEND=true`), and the notification hook (fires with correct env vars on success/partial success, does not fire on dry-run or when unconfigured)
- [x] Regression-tested the existing replace-mode (clear/fill/play) path to confirm no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)